### PR TITLE
Fix issue with ActionControllerRequest#request_uri not including the query string in the URI.

### DIFF
--- a/lib/api_auth/request_drivers/action_controller.rb
+++ b/lib/api_auth/request_drivers/action_controller.rb
@@ -33,7 +33,7 @@ module ApiAuth
       end
 
       def request_uri
-        @request.path
+        @request.request_uri
       end
 
       def timestamp

--- a/spec/api_auth_spec.rb
+++ b/spec/api_auth_spec.rb
@@ -133,6 +133,41 @@ describe "ApiAuth" do
       
     end
     
+    describe "with ActionController" do
+
+      before(:each) do
+        @request = ActionController::Request.new(
+          'PATH_INFO' => '/resource.xml',
+          'QUERY_STRING' => 'foo=bar&bar=foo',
+          'REQUEST_METHOD' => 'PUT',
+          'CONTENT_MD5' => 'e59ff97941044f85df5297e1c302d260',
+          'CONTENT_TYPE' => 'text/plain',
+          'HTTP_DATE' => 'Mon, 23 Jan 1984 03:29:56 GMT')
+        @signed_request = ApiAuth.sign!(@request, @access_id, @secret_key)
+      end
+
+      it "should return a ActionController::Request object after signing it" do
+        ApiAuth.sign!(@request, @access_id, @secret_key).class.to_s.should match("ActionController::Request")
+      end
+
+      it "should sign the request" do
+        @signed_request.env['Authorization'].should == "APIAuth 1044:#{hmac(@secret_key, @request)}"
+      end
+
+      it "should authenticate a valid request" do
+        ApiAuth.authentic?(@signed_request, @secret_key).should be_true
+      end
+
+      it "should NOT authenticate a non-valid request" do
+        ApiAuth.authentic?(@signed_request, @secret_key+'j').should be_false
+      end
+
+      it "should retrieve the access_id" do
+        ApiAuth.access_id(@signed_request).should == "1044"
+      end
+
+    end
+
   end
   
 end

--- a/spec/headers_spec.rb
+++ b/spec/headers_spec.rb
@@ -99,4 +99,39 @@ describe "ApiAuth::Headers" do
   
   end
   
+  describe "with ActionController" do
+
+    before(:each) do
+      @request = ActionController::Request.new(
+        'PATH_INFO' => '/resource.xml',
+        'QUERY_STRING' => 'foo=bar&bar=foo',
+        'REQUEST_METHOD' => 'PUT',
+        'CONTENT_MD5' => 'e59ff97941044f85df5297e1c302d260',
+        'CONTENT_TYPE' => 'text/plain',
+        'HTTP_DATE' => 'Mon, 23 Jan 1984 03:29:56 GMT')
+      @headers = ApiAuth::Headers.new(@request)
+    end
+
+    it "should generate the proper canonical string" do
+      @headers.canonical_string.should == CANONICAL_STRING
+    end
+
+    it "should set the authorization header" do
+      @headers.sign_header("alpha")
+      @headers.authorization_header.should == "alpha"
+    end
+
+    it "should set the DATE header if one is not already present" do
+      @request = ActionController::Request.new(
+        'PATH_INFO' => '/resource.xml',
+        'QUERY_STRING' => 'foo=bar&bar=foo',
+        'REQUEST_METHOD' => 'PUT',
+        'CONTENT_MD5' => 'e59ff97941044f85df5297e1c302d260',
+        'CONTENT_TYPE' => 'text/plain')
+      ApiAuth.sign!(@request, "some access id", "some secret key")
+      @request.headers['DATE'].should_not be_nil
+    end
+
+  end
+
 end


### PR DESCRIPTION
I ran into this issue while trying to get api-auth to work on Rails 2.3. This pull request fixes it.

**Issue:** `ActionControllerRequest#request_uri` was using `ActionController::Request#path`, which does not include the query string in the URI, instead of `#request_uri`. Because of this, `Headers#canonical_string` will end up being incorrect, causing authentication to fail.

**Fix:** I fixed `ActionControllerRequest#request_uri` to call `#request_uri` instead of `#path`. I also added RSpec tests to confirm its functionality. The canonical string test, in particular, will fail without the fix.

**Remarks:** I noticed @alexmchale actually [made this change](https://github.com/mgomes/api_auth/commit/d2e25702161b64cd97cc70ae7b1faecf3b7200d1#diff-0) when trying to get api-auth to work on Rails 3, but then [pulled it back out](https://github.com/mgomes/api_auth/commit/a4054d45cf636e2813999b659c80484da962a840#diff-2) in his final fix. Because of this, the issue was only addressed for Rails 3; requests still ended up failing when both client and server are running Rails 2.3.

**Special Request:** Once this pull request is approved, would you mind publishing a new version of your gem with this fix in it so that I can deploy it on my project? I would greatly appreciate it.

Thanks!
