### PR TITLE
Added check for HTTP_CONTENT_MD5 in the ActionController driver

### DIFF
--- a/lib/api_auth/request_drivers/action_controller.rb
+++ b/lib/api_auth/request_drivers/action_controller.rb
@@ -51,7 +51,7 @@ module ApiAuth
       end
 
       def content_md5
-        value = find_header(%w(CONTENT-MD5 CONTENT_MD5))
+        value = find_header(%w(CONTENT-MD5 CONTENT_MD5 HTTP_CONTENT_MD5))
         value.nil? ? "" : value
       end
 


### PR DESCRIPTION
I found that this was required. I am passing the Content-MD5 header from a node.js client app to a Rails 3.2.8 backend and it's ending up as HTTP_CONTENT_MD5 in Rails. It looks like other header fields have a check for the field name starting with HTTP as well, so it should make sense here as well.
