### PR TITLE
Quick fix for RestClient

### DIFF
--- a/lib/api_auth/headers.rb
+++ b/lib/api_auth/headers.rb
@@ -42,7 +42,7 @@ module ApiAuth
     def canonical_string
       [ @request.content_type,
         @request.content_md5,
-        @request.request_uri,
+        @request.request_uri.gsub(/http:\/\/[^(,|\?|\/)]*/,''), # remove host
         @request.timestamp
       ].join(",")
     end

--- a/lib/api_auth/request_drivers/rest_client.rb
+++ b/lib/api_auth/request_drivers/rest_client.rb
@@ -1,3 +1,6 @@
+# give access to RestClient @processed_headers
+module RestClient;class Request;attr_accessor :processed_headers;end;end
+
 module ApiAuth
 
   module RequestDrivers # :nodoc:
@@ -15,6 +18,7 @@ module ApiAuth
       def set_auth_header(header)
         @request.headers.merge!({ "Authorization" => header })
         @headers = fetch_headers
+        save_headers # enforce update of processed_headers based on last updated headers
         @request
       end
 
@@ -77,7 +81,11 @@ module ApiAuth
       def find_header(keys)
         keys.map {|key| @headers[key] }.compact.first
       end
-
+      
+      def save_headers
+        @request.processed_headers = @request.make_headers(@headers)
+      end
+      
     end
 
   end


### PR DESCRIPTION
Hi,

Thank you for this useful gem !

I had to make a small patch to make it work with RestClient::Request

request = RestClient::Request.new(...)
::ApiAuth.sign!(reques, _id, _secret)

When calling request.execute, RestClient::Request references request.processed_headers via request.transmit. ApiAuth modifies headers but not processed_headers.

The small change I added made it work for me, but I admit I had to do it fast and did not look much for alternative solutions.

Best,
Nico
