### PR TITLE
Rack::Request#body is a StringIO and should be reuseable

### DIFF
--- a/lib/api_auth/request_drivers/rack.rb
+++ b/lib/api_auth/request_drivers/rack.rb
@@ -20,7 +20,10 @@ module ApiAuth
 
       def calculated_md5
         if @request.body
+          # Make sure the request body is reusable
+          @request.body.rewind
           body = @request.body.read
+          @request.body.rewind
         else
           body = ''
         end


### PR DESCRIPTION
This is a little opinionated. I haven't run or written tests, feel free to look at the changes and then implement yourself.
