### PR TITLE
Use strict base64 coding, which omits newlines in the generated strings.

### DIFF
--- a/lib/api_auth/helpers.rb
+++ b/lib/api_auth/helpers.rb
@@ -2,9 +2,8 @@ module ApiAuth
 
   module Helpers # :nodoc:
     
-    # Remove the ending new line character added by default
     def b64_encode(string)
-      Base64.encode64(string).strip
+      Base64.strict_encode64(string)
     end
     
     # Capitalizes the keys of a hash

--- a/spec/api_auth_spec.rb
+++ b/spec/api_auth_spec.rb
@@ -8,8 +8,8 @@ describe "ApiAuth" do
       ApiAuth.generate_secret_key
     end
 
-    it "should generate secret keys that are 89 characters" do
-      ApiAuth.generate_secret_key.size.should be(89)
+    it "should generate secret keys that are 88 characters" do
+      ApiAuth.generate_secret_key.size.should be(88)
     end
 
     it "should generate keys that have a Hamming Distance of at least 65" do


### PR DESCRIPTION
This removes the newline characters inserted at character 60 from all encoded strings,
but more to the point, also removes it from the generated secret keys.
