### PR TITLE
Added support for sinatra

### DIFF
--- a/lib/api_auth/headers.rb
+++ b/lib/api_auth/headers.rb
@@ -25,8 +25,10 @@ module ApiAuth
         end
       when /ActionDispatch::Request/
         @request = ActionDispatchRequest.new(request)
-      when /Rack::Request/ || /Sinatra::Request/
+      when /Rack::Request/
         @request = RackRequest.new(request)
+      when /Sinatra::Request/
+          @request = RackRequest.new(request)
       else
         raise UnknownHTTPRequest, "#{request.class.to_s} is not yet supported."
       end


### PR DESCRIPTION
I implemented support for Sinatra::Request authenticity checking. Even Sinatra::Request is a Rack::Request class, the method of class checking does not detect subclasses.
