### PR TITLE
Fall back to stripping out newlines on Ruby 1.8.

### DIFF
--- a/lib/api_auth/helpers.rb
+++ b/lib/api_auth/helpers.rb
@@ -3,7 +3,12 @@ module ApiAuth
   module Helpers # :nodoc:
     
     def b64_encode(string)
-      Base64.strict_encode64(string)
+      if Base64.respond_to?(:strict_encode64)
+        Base64.strict_encode64(string)
+      else
+        # Fall back to stripping out newlines on Ruby 1.8.
+        Base64.encode64(string).gsub(/\n/, '')
+      end
     end
     
     # Capitalizes the keys of a hash


### PR DESCRIPTION
#22 introduced the use of `Base64::strict_encode64` so that generated keys and signatures don't end up having newlines; however, `Base64::strict_encode64` was introduced in Ruby 1.9. This adds the fallback handling for Ruby 1.8.
