### PR TITLE
rest-client: save the @request.headers

### DIFF
--- a/lib/api_auth/request_drivers/rest_client.rb
+++ b/lib/api_auth/request_drivers/rest_client.rb
@@ -17,7 +17,6 @@ module ApiAuth
 
       def set_auth_header(header)
         @request.headers.merge!({ "Authorization" => header })
-        @headers = fetch_headers
         save_headers # enforce update of processed_headers based on last updated headers
         @request
       end
@@ -47,7 +46,7 @@ module ApiAuth
       end
 
       def fetch_headers
-        capitalize_keys @request.headers
+        capitalize_keys @request.processed_headers
       end
 
       def content_type
@@ -84,7 +83,8 @@ module ApiAuth
       end
 
       def save_headers
-        @request.processed_headers = @request.make_headers(@headers)
+        @request.processed_headers = @request.make_headers(@request.headers)
+        @headers = fetch_headers
       end
 
     end

--- a/spec/headers_spec.rb
+++ b/spec/headers_spec.rb
@@ -91,6 +91,18 @@ describe "ApiAuth::Headers" do
       headers.canonical_string
       request.headers['DATE'].should be_nil
     end
+
+    it "doesn't mess up symbol based headers" do
+      headers = { 'Content-MD5' => "e59ff97941044f85df5297e1c302d260",
+                  :content_type => "text/plain",
+                  'Date' => "Mon, 23 Jan 1984 03:29:56 GMT" }
+      @request = RestClient::Request.new(:url => "/resource.xml?foo=bar&bar=foo",
+        :headers => headers,
+        :method => :put)
+      @headers = ApiAuth::Headers.new(@request)
+      ApiAuth.sign!(@request, "some access id", "some secret key")
+      @request.processed_headers.should have_key('Content-Type')
+    end
   end
 
   describe "with Curb" do


### PR DESCRIPTION
saving the capitalized unprocessed headers caused issues with
headers that were passed into rest-client with symbols for keys
