### PR TITLE
Invalid dates should not raise an error, but return false for ApiAuth.authentic?

### DIFF
--- a/lib/api_auth/base.rb
+++ b/lib/api_auth/base.rb
@@ -1,8 +1,5 @@
-# api-auth is Ruby gem designed to be used both in your client and server
-# HTTP-based applications. It implements the same authentication methods (HMAC)
-# used by Amazon Web Services.
-
-# The gem will sign your requests on the client side and authenticate that
+# encoding: UTF-8
+# api-auth is Ruby gem designed to be used both in your client and serve
 # signature on the server side. If your server resources are implemented as a
 # Rails ActiveResource, it will integrate with that. It will even generate the
 # secret keys necessary for your clients to sign their requests.
@@ -61,7 +58,7 @@ module ApiAuth
       headers = Headers.new(request)
       # 900 seconds is 15 minutes
       begin 
-        Time.parse(headers.timestamp).utc < (Time.now.utc - 900)
+        Time.httpdate(headers.timestamp).utc < (Time.now.utc - 900)
       rescue ArgumentError
         true
       end

--- a/spec/api_auth_spec.rb
+++ b/spec/api_auth_spec.rb
@@ -1,3 +1,4 @@
+# encoding: UTF-8
 require File.expand_path(File.dirname(__FILE__) + '/spec_helper')
 
 describe "ApiAuth" do


### PR DESCRIPTION
Ran into this issue on our API today, an invalid Date was being to sent to our servers, think it is better to return a fail authentication than raise an ArgumentError exception.
