### PR TITLE
Customizable auth header prefix

### DIFF
--- a/lib/api_auth/base.rb
+++ b/lib/api_auth/base.rb
@@ -99,7 +99,7 @@ module ApiAuth
 
     attr_writer :auth_header_prefix
 
-    def auth_header_prefix=(prefix)
+    def auth_header_prefix
       @auth_header_prefix || "APIAuth"
     end
 


### PR DESCRIPTION
Allow Authorization header prefix customisation. It is now hard-coded to `APIAuth`