### PR TITLE
Added support for Faraday::Request

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -35,6 +35,8 @@ GEM
     diff-lcs (1.1.3)
     erubis (2.6.6)
       abstract (>= 1.0.0)
+    faraday (0.9.1)
+      multipart-post (>= 1.2, < 3)
     httpi (2.1.0)
       rack
       rubyntlm (~> 0.3.2)
@@ -72,6 +74,7 @@ DEPENDENCIES
   api-auth!
   appraisal
   curb (~> 0.8.1)
+  faraday
   httpi
   multipart-post (~> 2.0)
   rake

--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ Here is the current list of supported request objects:
 * ActionDispatch::Request
 * Curb (Curl::Easy)
 * RestClient
+* Faraday
 
 ### HTTP Client Objects
 

--- a/api_auth.gemspec
+++ b/api_auth.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rest-client", "~> 1.6.0"
   s.add_development_dependency "curb", "~> 0.8.1"
   s.add_development_dependency "httpi"
+  s.add_development_dependency "faraday"
   s.add_development_dependency "multipart-post", "~> 2.0"
 
   s.files         = `git ls-files`.split("\n")

--- a/gemfiles/rails_23.gemfile.lock
+++ b/gemfiles/rails_23.gemfile.lock
@@ -20,6 +20,8 @@ GEM
       thor (>= 0.14.0)
     curb (0.8.6)
     diff-lcs (1.1.3)
+    faraday (0.9.1)
+      multipart-post (>= 1.2, < 3)
     httpi (2.1.0)
       rack
       rubyntlm (~> 0.3.2)
@@ -52,6 +54,7 @@ DEPENDENCIES
   api-auth!
   appraisal
   curb (~> 0.8.1)
+  faraday
   httpi
   multipart-post (~> 2.0)
   rake

--- a/gemfiles/rails_30.gemfile.lock
+++ b/gemfiles/rails_30.gemfile.lock
@@ -36,6 +36,8 @@ GEM
     diff-lcs (1.1.3)
     erubis (2.6.6)
       abstract (>= 1.0.0)
+    faraday (0.9.1)
+      multipart-post (>= 1.2, < 3)
     httpi (2.1.0)
       rack
       rubyntlm (~> 0.3.2)
@@ -74,6 +76,7 @@ DEPENDENCIES
   api-auth!
   appraisal
   curb (~> 0.8.1)
+  faraday
   httpi
   multipart-post (~> 2.0)
   rake

--- a/gemfiles/rails_31.gemfile.lock
+++ b/gemfiles/rails_31.gemfile.lock
@@ -35,6 +35,8 @@ GEM
     curb (0.8.6)
     diff-lcs (1.1.3)
     erubis (2.7.0)
+    faraday (0.9.1)
+      multipart-post (>= 1.2, < 3)
     hike (1.2.3)
     httpi (2.1.0)
       rack
@@ -80,6 +82,7 @@ DEPENDENCIES
   api-auth!
   appraisal
   curb (~> 0.8.1)
+  faraday
   httpi
   multipart-post (~> 2.0)
   rake

--- a/gemfiles/rails_32.gemfile.lock
+++ b/gemfiles/rails_32.gemfile.lock
@@ -34,6 +34,8 @@ GEM
     curb (0.8.6)
     diff-lcs (1.1.3)
     erubis (2.7.0)
+    faraday (0.9.1)
+      multipart-post (>= 1.2, < 3)
     hike (1.2.3)
     httpi (2.1.0)
       rack
@@ -79,6 +81,7 @@ DEPENDENCIES
   api-auth!
   appraisal
   curb (~> 0.8.1)
+  faraday
   httpi
   multipart-post (~> 2.0)
   rake

--- a/gemfiles/rails_4.gemfile.lock
+++ b/gemfiles/rails_4.gemfile.lock
@@ -35,6 +35,8 @@ GEM
     curb (0.8.6)
     diff-lcs (1.1.3)
     erubis (2.7.0)
+    faraday (0.9.1)
+      multipart-post (>= 1.2, < 3)
     httpi (2.1.0)
       rack
       rubyntlm (~> 0.3.2)
@@ -76,6 +78,7 @@ DEPENDENCIES
   api-auth!
   appraisal
   curb (~> 0.8.1)
+  faraday
   httpi
   multipart-post (~> 2.0)
   rake

--- a/gemfiles/rails_41.gemfile.lock
+++ b/gemfiles/rails_41.gemfile.lock
@@ -38,6 +38,8 @@ GEM
     curb (0.8.6)
     diff-lcs (1.1.3)
     erubis (2.7.0)
+    faraday (0.9.1)
+      multipart-post (>= 1.2, < 3)
     httpi (2.1.0)
       rack
       rubyntlm (~> 0.3.2)
@@ -80,6 +82,7 @@ DEPENDENCIES
   api-auth!
   appraisal
   curb (~> 0.8.1)
+  faraday
   httpi
   multipart-post (~> 2.0)
   rake

--- a/lib/api_auth.rb
+++ b/lib/api_auth.rb
@@ -11,6 +11,7 @@ require 'api_auth/request_drivers/action_controller'
 require 'api_auth/request_drivers/action_dispatch'
 require 'api_auth/request_drivers/rack'
 require 'api_auth/request_drivers/httpi'
+require 'api_auth/request_drivers/faraday'
 
 require 'api_auth/headers'
 require 'api_auth/base'

--- a/lib/api_auth/base.rb
+++ b/lib/api_auth/base.rb
@@ -17,7 +17,7 @@ module ApiAuth
     # Returns the HTTP request object with the modified headers.
     #
     # request: The request can be a Net::HTTP, ActionDispatch::Request,
-    # Curb (Curl::Easy) or a RestClient object.
+    # Curb (Curl::Easy), RestClient object or Faraday::Request.
     #
     # access_id: The public unique identifier for the client
     #
@@ -61,7 +61,7 @@ module ApiAuth
     def request_too_old?(request)
       headers = Headers.new(request)
       # 900 seconds is 15 minutes
-      begin 
+      begin
         Time.httpdate(headers.timestamp).utc < (Time.now.utc - 900)
       rescue ArgumentError
         true

--- a/lib/api_auth/headers.rb
+++ b/lib/api_auth/headers.rb
@@ -34,6 +34,8 @@ module ApiAuth
           ActionControllerRequest.new(request)
         when /HTTPI::Request/
           HttpiRequest.new(request)
+        when /Faraday::Request/
+          FaradayRequest.new(request)
         else
           nil
         end

--- a/lib/api_auth/request_drivers/faraday.rb
+++ b/lib/api_auth/request_drivers/faraday.rb
@@ -1,0 +1,86 @@
+module ApiAuth
+
+  module RequestDrivers # :nodoc:
+
+    class FaradayRequest # :nodoc:
+
+      include ApiAuth::Helpers
+
+      def initialize(request)
+        @request = request
+        @headers = fetch_headers
+        true
+      end
+
+      def set_auth_header(header)
+        @request.headers.merge!({ "Authorization" => header })
+        @headers = fetch_headers
+        @request
+      end
+
+      def calculated_md5
+        if @request.body
+          body = @request.body
+        else
+          body = ''
+        end
+        md5_base64digest(body)
+      end
+
+      def populate_content_md5
+        if ['POST', 'PUT'].include?(@request.method.to_s.upcase)
+          @request.headers["Content-MD5"] = calculated_md5
+        end
+      end
+
+      def md5_mismatch?
+        if ['POST', 'PUT'].include?(@request.method.to_s.upcase)
+          calculated_md5 != content_md5
+        else
+          false
+        end
+      end
+
+      def fetch_headers
+        capitalize_keys @request.headers
+      end
+
+      def content_type
+        value = find_header(%w(CONTENT-TYPE CONTENT_TYPE HTTP_CONTENT_TYPE))
+        value.nil? ? "" : value
+      end
+
+      def content_md5
+        value = find_header(%w(CONTENT-MD5 CONTENT_MD5 HTTP-CONTENT-MD5 HTTP_CONTENT_MD5))
+        value.nil? ? "" : value
+      end
+
+      def request_uri
+        uri = URI::HTTP.new(nil, nil, nil, nil, nil, @request.path, nil, @request.params.to_query, nil)
+        uri.to_s
+      end
+
+      def set_date
+        @request.headers.merge!({ "DATE" => Time.now.utc.httpdate })
+      end
+
+      def timestamp
+        value = find_header(%w(DATE HTTP_DATE))
+        value.nil? ? "" : value
+      end
+
+      def authorization_header
+        find_header %w(Authorization AUTHORIZATION HTTP_AUTHORIZATION)
+      end
+
+    private
+
+      def find_header(keys)
+        keys.map {|key| @headers[key] }.compact.first
+      end
+
+    end
+
+  end
+
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,6 +6,7 @@ require 'amatch'
 require 'rest_client'
 require 'curb'
 require 'httpi'
+require 'faraday'
 require 'net/http/post/multipart'
 
 require 'active_support'
@@ -20,5 +21,5 @@ require 'active_resource/http_mock'
 Dir["#{File.dirname(__FILE__)}/support/**/*.rb"].each {|f| require f}
 
 RSpec.configure do |config|
-  
+
 end


### PR DESCRIPTION
I previously made a pull request to directly support Typhoeus (#63) however we decided to use Typhoeus through it's Faraday adapter instead, thus I am back with another pull request. Faraday is actually probably a great addition for api-auth because it wraps many other HTTP clients libraries and probably more in the future. The standalone Typhoeus support still has it's merits as some people may want to use it directly instead of through Faraday.

https://github.com/lostisland/faraday
> Faraday is an HTTP client lib that provides a common interface over many adapters (such as Net::HTTP) and embraces the concept of Rack middleware when processing the request/response cycle.