### PR TITLE
Fix: Faraday signs urls that have no parameters correctly

### DIFF
--- a/lib/api_auth/request_drivers/faraday.rb
+++ b/lib/api_auth/request_drivers/faraday.rb
@@ -56,7 +56,9 @@ module ApiAuth
       end
 
       def request_uri
-        uri = URI::HTTP.new(nil, nil, nil, nil, nil, @request.path, nil, @request.params.to_query, nil)
+        query_string = @request.params.to_query
+        query_string = nil if query_string.empty?
+        uri = URI::HTTP.new(nil, nil, nil, nil, nil, @request.path, nil, query_string, nil)
         uri.to_s
       end
 


### PR DESCRIPTION
Also added appropriate specs to prevent it