### PR TITLE
Add a signed method to ActiveSupport::TestCase

### DIFF
--- a/lib/api_auth.rb
+++ b/lib/api_auth.rb
@@ -16,3 +16,5 @@ require 'api_auth/request_drivers/faraday'
 require 'api_auth/headers'
 require 'api_auth/base'
 require 'api_auth/railtie'
+
+require 'api_auth/extensions/action_controller/test_case'

--- a/lib/api_auth/extensions/action_controller/test_case.rb
+++ b/lib/api_auth/extensions/action_controller/test_case.rb
@@ -1,0 +1,24 @@
+module ActionController
+  class TestCase < ActiveSupport::TestCase
+    module Behavior
+
+      def signed(request_method, action, access_id, secret_key, parameters = nil, session = nil, flash = nil)
+        @request.env['API_AUTH_ACCESS_ID'] = access_id
+        @request.env['API_AUTH_SECRET_KEY'] ||= secret_key
+        __send__(request_method, action, parameters, session, flash).tap do
+          @request.env.delete 'API_AUTH_ACCESS_ID'
+          @request.env.delete 'API_AUTH_SECRET_KEY'
+        end
+      end
+
+    end
+  end
+
+  class Base
+    # Override so we can sign the request if the access_id and secret key have been set, now that all the headers have been set.
+    def process(action, *args)
+      ApiAuth.sign!(request, request.env['API_AUTH_ACCESS_ID'], request.env['API_AUTH_SECRET_KEY']) if request.env['API_AUTH_ACCESS_ID'] && request.env['API_AUTH_SECRET_KEY']
+      super
+    end
+  end
+end


### PR DESCRIPTION
When api_auth is used for authentication, you can no longer write controller tests without mocking or stubbing your authenticate method, but this may hide some bugs or unexpected behavior and short circuits the security layer of your API.

You can't sign the request directly in you test because before you call your action because headers aren't set yet so authentication will still fail.  

I've added a signed method that accepts the access_id and secret_key as parameters and will sign the request after the headers have been set.  I modeled it after the xhr method, so you you have to pass the verb as well.

```
              should 'have access to teams in other organizations' do
                team = create(:team)
                api_key = create(:api_key, role) # This creates a user with the passed in roll and an access_id and secret_key that belongs to that user.  This is an application detail your app must implement.

                signed :get, :index, api_key.access_id, api_key.secret_key, format: :json

                assert_response :success
              end
```