### PR TITLE
Allow use of other digests algorithms

### DIFF
--- a/spec/api_auth_spec.rb
+++ b/spec/api_auth_spec.rb
@@ -40,7 +40,7 @@ describe "ApiAuth" do
           'content-type' => 'text/plain',
           'content-md5' => '1B2M2Y8AsgTpgAmY7PhCfg==',
           'date' => Time.now.utc.httpdate)
-        @signed_request = ApiAuth.sign!(@request, @access_id, @secret_key, digest: 'sha512')
+        @signed_request = ApiAuth.sign!(@request, @access_id, @secret_key, :digest => 'sha512')
       end
 
       it "should sign request with sha512 digest algorithm" do
@@ -48,7 +48,7 @@ describe "ApiAuth" do
       end
 
       it "should authenticate a valid request signed with sha512 digest algorithm" do
-        ApiAuth.authentic?(@signed_request, @secret_key, digest: 'sha512').should be_true
+        ApiAuth.authentic?(@signed_request, @secret_key, :digest => 'sha512').should be_true
       end
     end
 

--- a/spec/api_auth_spec.rb
+++ b/spec/api_auth_spec.rb
@@ -44,7 +44,7 @@ describe "ApiAuth" do
       end
 
       it "should sign request with sha512 digest algorithm" do
-        @signed_request['Authorization'].should == "APIAuth 1044:#{hmac(@secret_key, @request, digest: 'sha512')}"
+        @signed_request['Authorization'].should == "APIAuth 1044:#{hmac(@secret_key, @request, :digest => 'sha512')}"
       end
 
       it "should authenticate a valid request signed with sha512 digest algorithm" do


### PR DESCRIPTION
This allows user to choose the used digest algorithm for hmac signature.
User can pass an `options` hash with `:digest` key to both `sign!` and
`authentic?` methods.

This is also fully compatible the old interface defaulting to sha1.



Similar feature was asked before in #16 