### PR TITLE
Adding ruby 2.2 and bumping appraisal

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ rvm:
   - 1.9.3
   - 2.1.5
   - 2.2.1
+  - 2.2.2
 gemfile:
   - gemfiles/rails_23.gemfile
   - gemfiles/rails_30.gemfile
@@ -30,6 +31,14 @@ matrix:
     - rvm: 2.2.1
       gemfile: gemfiles/rails_31.gemfile
     - rvm: 2.2.1
+      gemfile: gemfiles/rails_32.gemfile
+    - rvm: 2.2.2
+      gemfile: gemfiles/rails_23.gemfile
+    - rvm: 2.2.2
+      gemfile: gemfiles/rails_30.gemfile
+    - rvm: 2.2.2
+      gemfile: gemfiles/rails_31.gemfile
+    - rvm: 2.2.2
       gemfile: gemfiles/rails_32.gemfile
 
 notifications:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -27,9 +27,10 @@ GEM
     activesupport (3.0.20)
     amatch (0.2.10)
       tins (~> 0.3)
-    appraisal (0.5.2)
+    appraisal (2.1.0)
       bundler
       rake
+      thor (>= 0.14.0)
     builder (2.1.2)
     curb (0.8.6)
     diff-lcs (1.1.3)
@@ -48,7 +49,7 @@ GEM
       rack (>= 1.0.0)
     rack-test (0.5.7)
       rack (>= 1.0)
-    rake (0.9.2.2)
+    rake (10.4.2)
     rest-client (1.6.7)
       mime-types (>= 1.16)
     rspec (2.4.0)
@@ -60,6 +61,7 @@ GEM
       diff-lcs (~> 1.1.2)
     rspec-mocks (2.4.0)
     rubyntlm (0.3.4)
+    thor (0.19.1)
     tins (0.5.5)
     tzinfo (0.3.39)
 

--- a/gemfiles/rails_23.gemfile
+++ b/gemfiles/rails_23.gemfile
@@ -6,4 +6,4 @@ gem "actionpack", "~> 2.3.2"
 gem "activeresource", "~> 2.3.2"
 gem "activesupport", "~> 2.3.2"
 
-gemspec :path=>"../"
+gemspec :path => "../"

--- a/gemfiles/rails_30.gemfile
+++ b/gemfiles/rails_30.gemfile
@@ -6,4 +6,4 @@ gem "actionpack", "~> 3.0.20"
 gem "activeresource", "~> 3.0.20"
 gem "activesupport", "~> 3.0.20"
 
-gemspec :path=>"../"
+gemspec :path => "../"

--- a/gemfiles/rails_31.gemfile
+++ b/gemfiles/rails_31.gemfile
@@ -6,4 +6,4 @@ gem "actionpack", "~> 3.1.0"
 gem "activeresource", "~> 3.1.0"
 gem "activesupport", "~> 3.1.0"
 
-gemspec :path=>"../"
+gemspec :path => "../"

--- a/gemfiles/rails_32.gemfile
+++ b/gemfiles/rails_32.gemfile
@@ -6,4 +6,4 @@ gem "actionpack", "~> 3.2.17"
 gem "activeresource", "~> 3.2.17"
 gem "activesupport", "~> 3.2.17"
 
-gemspec :path=>"../"
+gemspec :path => "../"

--- a/gemfiles/rails_4.gemfile
+++ b/gemfiles/rails_4.gemfile
@@ -6,4 +6,4 @@ gem "actionpack", "~> 4.0.4"
 gem "activeresource", "~> 4.0.0"
 gem "activesupport", "~> 4.0.4"
 
-gemspec :path=>"../"
+gemspec :path => "../"

--- a/gemfiles/rails_41.gemfile
+++ b/gemfiles/rails_41.gemfile
@@ -6,4 +6,4 @@ gem "actionpack", "~> 4.1.0"
 gem "activeresource", "~> 4.0.0"
 gem "activesupport", "~> 4.1.0"
 
-gemspec :path=>"../"
+gemspec :path => "../"


### PR DESCRIPTION
I believe it's a known issue in other libraries. Simply without test-unit running rspecs like:
```
bundle exec rake
```
throws ```cannot load such file -- test/unit/testcase (LoadError)``` like:
```
~/.rvm/gems/ruby-2.2.2/gems/activesupport-3.0.20/lib/active_support/dependencies.rb:242:in `require': cannot load such file -- test/unit/testcase (LoadError)
```

Adding unit-test to development dependencies seems to be the most common solution for that. The issue only exist in Ruby ```2.2.2```. It works fine without this patch with ```2.1.5```.