### PR TITLE
Fix canonical_string to return / for uri if only hostname is in client request

### DIFF
--- a/lib/api_auth/headers.rb
+++ b/lib/api_auth/headers.rb
@@ -55,7 +55,7 @@ module ApiAuth
     def canonical_string
       [ @request.content_type,
         @request.content_md5,
-        @request.request_uri.gsub(/https?:\/\/[^(,|\?|\/)]*/,''), # remove host
+        parse_uri(@request.request_uri), 
         @request.timestamp
       ].join(",")
     end
@@ -90,6 +90,12 @@ module ApiAuth
       @request.set_auth_header header
     end
 
-  end
+    private
 
+    def parse_uri(uri)
+      uri.gsub!(/https?:\/\/[^(,|\?|\/)]*/, '') # remove host
+      return '/' if uri.empty?
+      uri
+    end
+  end
 end

--- a/lib/api_auth/headers.rb
+++ b/lib/api_auth/headers.rb
@@ -93,9 +93,9 @@ module ApiAuth
     private
 
     def parse_uri(uri)
-      uri.gsub!(/https?:\/\/[^(,|\?|\/)]*/, '') # remove host
-      return '/' if uri.empty?
-      uri
+      uri_without_host = uri.gsub(/https?:\/\/[^(,|\?|\/)]*/, '')
+      return '/' if uri_without_host.empty?
+      uri_without_host
     end
   end
 end

--- a/spec/headers_spec.rb
+++ b/spec/headers_spec.rb
@@ -1,6 +1,6 @@
 require File.expand_path(File.dirname(__FILE__) + '/spec_helper')
 
-describe "ApiAuth::Headers" do
+describe ApiAuth::Headers do
 
   CANONICAL_STRING = "text/plain,e59ff97941044f85df5297e1c302d260,/resource.xml?foo=bar&bar=foo,Mon, 23 Jan 1984 03:29:56 GMT"
 
@@ -300,4 +300,15 @@ describe "ApiAuth::Headers" do
      end
    end
 
+   describe '#canonical_string' do
+     subject { described_class.new(RestClient::Request.new(:url => uri, :method => :get)) }
+   
+     context 'empty request uri' do
+       let(:uri) { '' }
+
+       it 'adds / to canonical string' do
+         subject.canonical_string.should eq(",,/,")
+       end
+     end
+   end
 end

--- a/spec/headers_spec.rb
+++ b/spec/headers_spec.rb
@@ -300,15 +300,40 @@ describe ApiAuth::Headers do
      end
    end
 
-   describe '#canonical_string' do
-     subject { described_class.new(RestClient::Request.new(:url => uri, :method => :get)) }
-   
-     context 'empty request uri' do
-       let(:uri) { '' }
+  describe '#canonical_string' do
+    let(:request) { RestClient::Request.new(:url => uri, :method => :get) }
+    subject { described_class.new(request) }
 
-       it 'adds / to canonical string' do
-         subject.canonical_string.should eq(",,/,")
-       end
-     end
-   end
+    context 'empty uri' do
+      let(:uri) { '' }
+
+      it 'adds / to canonical string' do
+        subject.canonical_string.should eq(',,/,')
+      end
+    end
+
+    context 'uri with just host without /' do
+      let(:uri) { 'http://google.com' }
+
+      it 'return / as canonical string path' do
+        subject.canonical_string.should eq(',,/,')
+      end
+
+      it 'does not change request url (by removing host)' do
+        request.url.should eq(uri)
+      end
+    end
+
+    context 'uri with host and /' do
+      let(:uri) { 'http://google.com/' }
+
+      it 'return / as canonical string path' do
+        subject.canonical_string.should eq(',,/,')
+      end
+
+      it 'does not change request url (by removing host)' do
+        request.url.should eq(uri)
+      end
+    end
+  end
 end

--- a/spec/headers_spec.rb
+++ b/spec/headers_spec.rb
@@ -305,7 +305,7 @@ describe ApiAuth::Headers do
     subject { described_class.new(request) }
 
     context 'empty uri' do
-      let(:uri) { '' }
+      let(:uri) { ''.freeze }
 
       it 'adds / to canonical string' do
         subject.canonical_string.should eq(',,/,')
@@ -313,7 +313,7 @@ describe ApiAuth::Headers do
     end
 
     context 'uri with just host without /' do
-      let(:uri) { 'http://google.com' }
+      let(:uri) { 'http://google.com'.freeze }
 
       it 'return / as canonical string path' do
         subject.canonical_string.should eq(',,/,')
@@ -325,7 +325,7 @@ describe ApiAuth::Headers do
     end
 
     context 'uri with host and /' do
-      let(:uri) { 'http://google.com/' }
+      let(:uri) { 'http://google.com/'.freeze }
 
       it 'return / as canonical string path' do
         subject.canonical_string.should eq(',,/,')


### PR DESCRIPTION
Suppose that I'm building and signing request on the client side with only hostname like:
```
r = RestClient::Request.new(url: 'http://test.com', method: :get) # missing / after .com
ApiAuth.sign!(r, 'user', 'secret')
r.execute
```
And then I'm checking the authorization on the server side:
```
ApiAuth.authentic?(request, 'secret')
```
It will never work when uri is just a hostname without / at the end since canonical_string is different ```,,,,``` vs ```,,/,``` since server treats the call as the call to the ```http://test.com/``` (with / at the end).
But I believe the client calls 
```
RestClient::Request.new(url: 'http://test.com', method: :get)
RestClient::Request.new(url: 'http://test.com/', method: :get)
```
should be treated the same way.
This made me debugging api_auth for quite sometime.
