### PR TITLE
Update #api_authenticate example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,16 +160,15 @@ whether or not the request is authentic. Typically, the access id for the client
 will be their record's primary key in the DB that stores the record or some other
 public unique identifier for the client.
 
-Here's a sample method that can be used in a `before_filter` if your server is a
+Here's a sample method that can be used in a `before_action` if your server is a
 Rails app:
 
 ``` ruby
-    before_filter :api_authenticate
+    before_action :api_authenticate
 
     def api_authenticate
       @current_account = Account.find_by_access_id(ApiAuth.access_id(request))
-      return ApiAuth.authentic?(request, @current_account.secret_key) unless @current_account.nil?
-      false
+      head(401) unless !@current_account.nil? && ApiAuth.authentic?(request, @current_account.secret_key)
     end
 ```
 

--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ Rails app:
 
     def api_authenticate
       @current_account = Account.find_by_access_id(ApiAuth.access_id(request))
-      head(401) unless !@current_account.nil? && ApiAuth.authentic?(request, @current_account.secret_key)
+      head(401) unless @current_account && ApiAuth.authentic?(request, @current_account.secret_key)
     end
 ```
 

--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ Rails app:
 
     def api_authenticate
       @current_account = Account.find_by_access_id(ApiAuth.access_id(request))
-      head(401) unless @current_account && ApiAuth.authentic?(request, @current_account.secret_key)
+      head(:unauthorized) unless @current_account && ApiAuth.authentic?(request, @current_account.secret_key)
     end
 ```
 


### PR DESCRIPTION
This example was broken because before_filters & before_actions
need to render or redirect in order to prevent actions from being called.

The example also uses a before_action now since it is preferred
over before_filter.

Let me know if you'd like to merge this but want me to make some changes first!