### PR TITLE
Avoid reallocating static Regexps

### DIFF
--- a/lib/api_auth/base.rb
+++ b/lib/api_auth/base.rb
@@ -67,6 +67,8 @@ module ApiAuth
 
   private
 
+    AUTH_HEADER_PATTERN = /^APIAuth ([^:]+):(.+)$/
+
     def request_too_old?(headers)
       # 900 seconds is 15 minutes
       begin
@@ -96,7 +98,7 @@ module ApiAuth
     end
 
     def parse_auth_header(auth_header)
-      Regexp.new("APIAuth ([^:]+):(.+)$").match(auth_header)
+      AUTH_HEADER_PATTERN.match(auth_header)
     end
 
   end # class methods

--- a/lib/api_auth/base.rb
+++ b/lib/api_auth/base.rb
@@ -67,7 +67,7 @@ module ApiAuth
 
   private
 
-    AUTH_HEADER_PATTERN = /^APIAuth ([^:]+):(.+)$/
+    AUTH_HEADER_PATTERN = /APIAuth ([^:]+):(.+)$/
 
     def request_too_old?(headers)
       # 900 seconds is 15 minutes

--- a/lib/api_auth/headers.rb
+++ b/lib/api_auth/headers.rb
@@ -55,7 +55,7 @@ module ApiAuth
     def canonical_string
       [ @request.content_type,
         @request.content_md5,
-        parse_uri(@request.request_uri), 
+        parse_uri(@request.request_uri),
         @request.timestamp
       ].join(",")
     end
@@ -92,8 +92,10 @@ module ApiAuth
 
     private
 
+    URI_WITHOUT_HOST_REGEXP = %r{https?://[^,?/]*}
+
     def parse_uri(uri)
-      uri_without_host = uri.gsub(/https?:\/\/[^(,|\?|\/)]*/, '')
+      uri_without_host = uri.gsub(URI_WITHOUT_HOST_REGEXP, '')
       return '/' if uri_without_host.empty?
       uri_without_host
     end

--- a/spec/api_auth_spec.rb
+++ b/spec/api_auth_spec.rb
@@ -90,6 +90,11 @@ describe "ApiAuth" do
         ApiAuth.authentic?(@signed_request, @secret_key).should be_true
       end
 
+      it "should authenticate a request with a prefix before APIAuth in the authorization header" do
+        @signed_request['Authorization'] = 'Corporate' + @signed_request['Authorization']
+        ApiAuth.authentic?(@signed_request, @secret_key).should be_true
+      end
+
       it "should NOT authenticate a non-valid request" do
         ApiAuth.authentic?(@signed_request, @secret_key+'j').should be_false
       end


### PR DESCRIPTION
This also simplifies the regexp used in `parse_uri` for stripping the
scheme and hostname from a URI.

As before, profiling and/or benchmarking using this script:

https://gist.github.com/pd/df5b38fed1291e82f672

Note the output of "api-auth-1.4.0", which does not exist; I'm just
using that as a cheap form of "I built master and wanted to install
it separately from the actual gem I use every day."

Benchmark before and after:

~~~
$ V=gem M=bench command ruby profile.rb
/Users/khargraves/.gem/ruby/2.2.2/gems/api-auth-1.4.0/lib/api_auth/errors.rb
Calculating -------------------------------------
          authentic?     1.765k i/100ms
-------------------------------------------------
          authentic?     18.406k (± 3.0%) i/s -     37.065k

$ V=local M=bench command ruby profile.rb
/Users/khargraves/sauce/rb/api_auth/lib/api_auth/errors.rb
Calculating -------------------------------------
          authentic?     2.341k i/100ms
-------------------------------------------------
          authentic?     25.007k (± 2.1%) i/s -     51.502k
~~~