### PR TITLE
Add http method to the canonical string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,39 @@
+# 1.4 (?)
+
+## IMPORTANT SECURITY FIX (with backwards compatible fallback)
+
+  This version introduces a security fix. In previous versions, the canonical
+  string does not include the http method used to make the request, this means
+  two requests that would otherwise be identical (such as a GET and DELETE)
+  would have the same signature allowing for a MITM to swap one method for
+  another.
+
+  In ApiAuth v1.4 `ApiAuth.authentic?` will allow for requests signed using either
+  the canonical string WITH the http method, or WITHOUT it. `ApiAuth.sign!` will,
+  by default, still sign the request using the canonical string without the
+  method. However, passing in the `:with_http_method => true` option into
+  `ApiAuth.sign?` will cause the request to use the http method as part of the
+  canonical string.
+
+  Example:
+
+  ```ruby
+    ApiAuth.sign!(request, access_id, secret_key, {:with_http_method => true})
+  ```
+
+  This allows for an upgrade strategy that would look like the following.
+
+  1. Update server side code to use ApiAuth v1.4
+  2. Update client side code to use ApiAuth v1.4
+  3. Update all client side code to sign with http method
+  4. Update server side code to ApiAuth v2.0 (removes the ability to authenticate without the http method)
+  5. Update all client side code to ApiAuth v2.0 (forces all signatures to contain the http method)
+
+## Additional changes
+
+  - Performance enhancement: reduce allocation of Headers object (#81 pd)
+  - Performance enhancement: avoid reallocating static Regexps (#82 pd)
+
 # 1.3.2 (2015-08-28)
 - Fixed a bug where some client adapters didn't treat an empty path as
   "/" in the canonical string (#75 managr)

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 [![Build Status](https://travis-ci.org/mgomes/api_auth.png?branch=master)](https://travis-ci.org/mgomes/api_auth)
 
+## IMPORTANT: See [CHANGELOG.md](/CHANGELOG.md) for security update information
+
 Logins and passwords are for humans. Communication between applications need to
 be protected through different means.
 
@@ -25,7 +27,7 @@ content-MD5 are not present, then a blank string is used in their place. If the
 timestamp isn't present, a valid HTTP date is automatically added to the
 request. The canonical string is computed as follows:
 
-    canonical_string = 'content-type,content-MD5,request URI,timestamp'
+    canonical_string = 'http method,content-type,content-MD5,request URI,timestamp'
 
 2. This string is then used to create the signature which is a Base64 encoded
 SHA1 HMAC, using the client's private secret key.
@@ -73,9 +75,7 @@ Here is the current list of supported request objects:
 
 ### HTTP Client Objects
 
-Here's a sample implementation of signing a request created with RestClient. For
-more examples, please check out the ApiAuth Spec where every supported HTTP
-client is tested.
+Here's a sample implementation of signing a request created with RestClient.
 
 Assuming you have a client access id and secret as follows:
 
@@ -106,6 +106,14 @@ object and it's ready to be transmitted. It's recommended that you sign the
 request as one of the last steps in building the request to ensure the headers
 don't change after the signing process which would cause the authentication
 check to fail on the server side.
+
+If you are signing a request for a driver that doesn't support automatic http
+method detection (like Curb or httpi), you can pass the http method as an option
+into the sign! method like so:
+
+``` ruby
+    @signed_request = ApiAuth.sign!(@request, @access_id, @secret_key, :override_http_method => "PUT")
+```
 
 ### ActiveResource Clients
 

--- a/lib/api_auth/base.rb
+++ b/lib/api_auth/base.rb
@@ -22,11 +22,12 @@ module ApiAuth
     # access_id: The public unique identifier for the client
     #
     # secret_key: assigned secret key that is known to both parties
-    def sign!(request, access_id, secret_key)
+    def sign!(request, access_id, secret_key, options = {})
+      options = { :override_http_method => nil, :with_http_method => false }.merge(options)
       headers = Headers.new(request)
       headers.calculate_md5
       headers.set_date
-      headers.sign_header auth_header(headers, access_id, secret_key)
+      headers.sign_header auth_header(headers, access_id, secret_key, options)
     end
 
     # Determines if the request is authentic given the request and the client's
@@ -102,8 +103,8 @@ module ApiAuth
       b64_encode(OpenSSL::HMAC.digest(digest, secret_key, canonical_string))
     end
 
-    def auth_header(headers, access_id, secret_key)
-      "APIAuth #{access_id}:#{hmac_signature(headers, secret_key, {})}"
+    def auth_header(headers, access_id, secret_key, options)
+      "APIAuth #{access_id}:#{hmac_signature(headers, secret_key, options)}"
     end
 
     def parse_auth_header(auth_header)

--- a/lib/api_auth/headers.rb
+++ b/lib/api_auth/headers.rb
@@ -52,8 +52,26 @@ module ApiAuth
     end
 
     # Returns the canonical string computed from the request's headers
-    def canonical_string
+    def canonical_string_without_http_method
       [ @request.content_type,
+        @request.content_md5,
+        parse_uri(@request.request_uri),
+        @request.timestamp
+      ].join(",")
+    end
+
+    # temp backwards compatibility
+    alias_method :canonical_string, :canonical_string_without_http_method
+
+    def canonical_string_with_http_method(override_method = nil)
+      request_method = override_method || @request.http_method
+
+      if request_method.nil?
+        raise ArgumentError, "unable to determine the http method from the request, please supply an override"
+      end
+
+      [ request_method.upcase,
+        @request.content_type,
         @request.content_md5,
         parse_uri(@request.request_uri),
         @request.timestamp

--- a/lib/api_auth/request_drivers/action_controller.rb
+++ b/lib/api_auth/request_drivers/action_controller.rb
@@ -41,6 +41,10 @@ module ApiAuth
         capitalize_keys @request.env
       end
 
+      def http_method
+        @request.request_method.to_s.upcase
+      end
+
       def content_type
         value = find_header(%w(CONTENT-TYPE CONTENT_TYPE HTTP_CONTENT_TYPE))
         value.nil? ? "" : value

--- a/lib/api_auth/request_drivers/curb.rb
+++ b/lib/api_auth/request_drivers/curb.rb
@@ -30,6 +30,10 @@ module ApiAuth
         capitalize_keys @request.headers
       end
 
+      def http_method
+        nil # not possible to get the method at this layer
+      end
+
       def content_type
         value = find_header(%w(CONTENT-TYPE CONTENT_TYPE HTTP_CONTENT_TYPE))
         value.nil? ? "" : value

--- a/lib/api_auth/request_drivers/faraday.rb
+++ b/lib/api_auth/request_drivers/faraday.rb
@@ -45,6 +45,10 @@ module ApiAuth
         capitalize_keys @request.headers
       end
 
+      def http_method
+        @request.method.to_s.upcase
+      end
+
       def content_type
         value = find_header(%w(CONTENT-TYPE CONTENT_TYPE HTTP_CONTENT_TYPE))
         value.nil? ? "" : value

--- a/lib/api_auth/request_drivers/httpi.rb
+++ b/lib/api_auth/request_drivers/httpi.rb
@@ -40,6 +40,10 @@ module ApiAuth
         capitalize_keys @request.headers
       end
 
+      def http_method
+        nil # not possible to get the method at this layer
+      end
+
       def content_type
         value = find_header(%w(CONTENT-TYPE CONTENT_TYPE HTTP_CONTENT_TYPE))
         value.nil? ? "" : value

--- a/lib/api_auth/request_drivers/net_http.rb
+++ b/lib/api_auth/request_drivers/net_http.rb
@@ -47,6 +47,10 @@ module ApiAuth
         @request
       end
 
+      def http_method
+        @request.method.upcase
+      end
+
       def content_type
         value = find_header(%w(CONTENT-TYPE CONTENT_TYPE HTTP_CONTENT_TYPE))
         value.nil? ? "" : value

--- a/lib/api_auth/request_drivers/rack.rb
+++ b/lib/api_auth/request_drivers/rack.rb
@@ -46,6 +46,10 @@ module ApiAuth
         capitalize_keys @request.env
       end
 
+      def http_method
+        @request.request_method.upcase
+      end
+
       def content_type
         value = find_header(%w(CONTENT-TYPE CONTENT_TYPE HTTP_CONTENT_TYPE))
         value.nil? ? "" : value

--- a/lib/api_auth/request_drivers/rest_client.rb
+++ b/lib/api_auth/request_drivers/rest_client.rb
@@ -50,6 +50,10 @@ module ApiAuth
         capitalize_keys @request.processed_headers
       end
 
+      def http_method
+        @request.method.to_s.upcase
+      end
+
       def content_type
         value = find_header(%w(CONTENT-TYPE CONTENT_TYPE HTTP_CONTENT_TYPE))
         value.nil? ? "": value

--- a/spec/api_auth_spec.rb
+++ b/spec/api_auth_spec.rb
@@ -57,6 +57,24 @@ describe "ApiAuth" do
       signature = hmac("123", request)
       expect(request.headers['Authorization']).to eq("APIAuth 1044:#{signature}")
     end
+
+    context "when passed the with_http_method option" do
+      let(:request){
+        Net::HTTP::Put.new("/resource.xml?foo=bar&bar=foo",
+          'content-type' => 'text/plain',
+          'content-md5' => '1B2M2Y8AsgTpgAmY7PhCfg==',
+          'date' => Time.now.utc.httpdate
+        )
+      }
+
+      let(:canonical_string){ ApiAuth::Headers.new(request).canonical_string_with_http_method }
+
+      it "calculates the hmac_signature with http method" do
+        ApiAuth.sign!(request, "1044", "123", { :with_http_method => true })
+        signature = hmac("123", request, canonical_string)
+        expect(request['Authorization']).to eq("APIAuth 1044:#{signature}")
+      end
+    end
   end
 
   describe ".authentic?" do

--- a/spec/request_drivers/action_controller_spec.rb
+++ b/spec/request_drivers/action_controller_spec.rb
@@ -54,6 +54,28 @@ if defined?(ActionController::Request)
           expect(driven_request.calculated_md5).to eq('1B2M2Y8AsgTpgAmY7PhCfg==')
         end
       end
+
+      describe "http_method" do
+        context "when put request" do
+          let(:request) do
+            ActionController::Request.new('REQUEST_METHOD' => 'PUT')
+          end
+
+          it "returns upcased put" do
+            expect(driven_request.http_method).to eq('PUT')
+          end
+        end
+
+        context "when get request" do
+          let(:request) do
+            ActionController::Request.new('REQUEST_METHOD' => 'GET')
+          end
+
+          it "returns upcased get" do
+            expect(driven_request.http_method).to eq('GET')
+          end
+        end
+      end
     end
 
     describe "setting headers correctly" do

--- a/spec/request_drivers/action_dispatch_spec.rb
+++ b/spec/request_drivers/action_dispatch_spec.rb
@@ -54,6 +54,29 @@ if defined?(ActionDispatch::Request)
           expect(driven_request.calculated_md5).to eq('1B2M2Y8AsgTpgAmY7PhCfg==')
         end
       end
+
+
+      describe "http_method" do
+        context "when put request" do
+          let(:request) do
+            ActionDispatch::Request.new('REQUEST_METHOD' => 'PUT')
+          end
+
+          it "returns upcased put" do
+            expect(driven_request.http_method).to eq('PUT')
+          end
+        end
+
+        context "when get request" do
+          let(:request) do
+            ActionDispatch::Request.new('REQUEST_METHOD' => 'GET')
+          end
+
+          it "returns upcased get" do
+            expect(driven_request.http_method).to eq('GET')
+          end
+        end
+      end
     end
 
     describe "setting headers correctly" do

--- a/spec/request_drivers/curb_spec.rb
+++ b/spec/request_drivers/curb_spec.rb
@@ -39,6 +39,12 @@ describe ApiAuth::RequestDrivers::CurbRequest do
     it "gets the authorization_header" do
       expect(driven_request.authorization_header).to eq('APIAuth 1044:12345')
     end
+
+    describe "http_method" do
+      it "is always nil" do
+        expect(driven_request.http_method).to be_nil
+      end
+    end
   end
 
   describe "setting headers correctly" do

--- a/spec/request_drivers/faraday_spec.rb
+++ b/spec/request_drivers/faraday_spec.rb
@@ -7,6 +7,7 @@ describe ApiAuth::RequestDrivers::FaradayRequest do
   let(:faraday_stubs) do
     Faraday::Adapter::Test::Stubs.new do |stub|
       stub.put('/resource.xml?foo=bar&bar=foo') { [200, {}, ''] }
+      stub.get('/resource.xml?foo=bar&bar=foo') { [200, {}, ''] }
       stub.put('/resource.xml') { [200, {}, ''] }
     end
   end
@@ -68,6 +69,42 @@ describe ApiAuth::RequestDrivers::FaradayRequest do
       it "treats no body as empty string" do
         request.body = nil
         expect(driven_request.calculated_md5).to eq('1B2M2Y8AsgTpgAmY7PhCfg==')
+      end
+    end
+
+    describe "http_method" do
+      context "when put request" do
+        let(:request) do
+          faraday_request = nil
+
+          faraday_conn.put '/resource.xml?foo=bar&bar=foo', "hello\nworld" do |request|
+            faraday_request = request
+            faraday_request.headers.merge!(request_headers)
+          end
+
+          faraday_request
+        end
+
+        it "returns upcased put" do
+          expect(driven_request.http_method).to eq('PUT')
+        end
+      end
+
+      context "when get request" do
+        let(:request) do
+          faraday_request = nil
+
+          faraday_conn.get '/resource.xml?foo=bar&bar=foo' do |request|
+            faraday_request = request
+            faraday_request.headers.merge!(request_headers)
+          end
+
+          faraday_request
+        end
+
+        it "returns upcased get" do
+          expect(driven_request.http_method).to eq('GET')
+        end
       end
     end
   end

--- a/spec/request_drivers/httpi_spec.rb
+++ b/spec/request_drivers/httpi_spec.rb
@@ -49,6 +49,12 @@ describe ApiAuth::RequestDrivers::HttpiRequest do
         expect(driven_request.calculated_md5).to eq('1B2M2Y8AsgTpgAmY7PhCfg==')
       end
     end
+
+    describe "http_method" do
+      it "is always nil" do
+        expect(driven_request.http_method).to be_nil
+      end
+    end
   end
 
   describe "setting headers correctly" do

--- a/spec/request_drivers/net_http_spec.rb
+++ b/spec/request_drivers/net_http_spec.rb
@@ -69,6 +69,24 @@ describe ApiAuth::RequestDrivers::NetHttpRequest do
         expect(driven_request.calculated_md5).to eq('k4U8MTA3RHDcewBzymVNEQ==')
       end
     end
+
+    describe "http_method" do
+      context "when put request" do
+        let(:request){ Net::HTTP::Put.new(request_path, request_headers) }
+
+        it "returns upcased put" do
+          expect(driven_request.http_method).to eq('PUT')
+        end
+      end
+
+      context "when get request" do
+        let(:request){ Net::HTTP::Get.new(request_path, request_headers) }
+
+        it "returns upcased get" do
+          expect(driven_request.http_method).to eq('GET')
+        end
+      end
+    end
   end
 
   describe "setting headers correctly" do

--- a/spec/request_drivers/rack_spec.rb
+++ b/spec/request_drivers/rack_spec.rb
@@ -64,6 +64,38 @@ describe ApiAuth::RequestDrivers::RackRequest do
         expect(driven_request.calculated_md5).to eq('1B2M2Y8AsgTpgAmY7PhCfg==')
       end
     end
+
+    describe "http_method" do
+      context "when put request" do
+        let(:request) do
+          Rack::Request.new(
+            Rack::MockRequest.env_for(
+              request_path,
+              :method => :put
+            ).merge!(request_headers)
+          )
+        end
+
+        it "returns upcased put" do
+          expect(driven_request.http_method).to eq('PUT')
+        end
+      end
+
+      context "when get request" do
+        let(:request) do
+          Rack::Request.new(
+            Rack::MockRequest.env_for(
+              request_path,
+              :method => :get
+            ).merge!(request_headers)
+          )
+        end
+
+        it "returns upcased get" do
+          expect(driven_request.http_method).to eq('GET')
+        end
+      end
+    end
   end
 
   describe "setting headers correctly" do

--- a/spec/request_drivers/rest_client_spec.rb
+++ b/spec/request_drivers/rest_client_spec.rb
@@ -62,6 +62,36 @@ describe ApiAuth::RequestDrivers::RestClientRequest do
         expect(driven_request.calculated_md5).to eq('1B2M2Y8AsgTpgAmY7PhCfg==')
       end
     end
+
+    describe "http_method" do
+      context "when put request" do
+        let(:request) do
+          RestClient::Request.new(
+            :url => "/resource.xml?foo=bar&bar=foo",
+            :headers => request_headers,
+            :method => :put
+          )
+        end
+
+        it "returns upcased put" do
+          expect(driven_request.http_method).to eq('PUT')
+        end
+      end
+
+      context "when get request" do
+        let(:request) do
+          RestClient::Request.new(
+            :url => "/resource.xml?foo=bar&bar=foo",
+            :headers => request_headers,
+            :method => :get
+          )
+        end
+
+        it "returns upcased get" do
+          expect(driven_request.http_method).to eq('GET')
+        end
+      end
+    end
   end
 
   describe "setting headers correctly" do


### PR DESCRIPTION
Fixes #73 

I still need to add some docs to the README, but here's the code changes. Let me know if this makes sense.