### PR TITLE
only load railtie if rails is present

### DIFF
--- a/lib/api_auth.rb
+++ b/lib/api_auth.rb
@@ -15,4 +15,4 @@ require 'api_auth/request_drivers/faraday'
 
 require 'api_auth/headers'
 require 'api_auth/base'
-require 'api_auth/railtie'
+require 'api_auth/railtie' if defined?(::Rails)

--- a/lib/api_auth.rb
+++ b/lib/api_auth.rb
@@ -15,4 +15,4 @@ require 'api_auth/request_drivers/faraday'
 
 require 'api_auth/headers'
 require 'api_auth/base'
-require 'api_auth/railtie' if defined?(::Rails)
+require 'api_auth/railtie'

--- a/lib/api_auth/railtie.rb
+++ b/lib/api_auth/railtie.rb
@@ -18,18 +18,6 @@ module ApiAuth
 
       end
 
-      unless defined?(ActionController)
-        begin
-          require 'rubygems'
-          gem 'actionpack'
-          gem 'activesupport'
-          require 'action_controller'
-          require 'active_support'
-        rescue LoadError
-          nil
-        end
-      end
-
       if defined?(ActionController::Base)
         ActionController::Base.send(:include, ControllerMethods::InstanceMethods)
       end
@@ -112,16 +100,6 @@ module ApiAuth
         end
 
       end # Connection
-
-      unless defined?(ActiveResource)
-        begin
-          require 'rubygems'
-          gem 'activeresource'
-          require 'active_resource'
-        rescue LoadError
-          nil
-        end
-      end
 
       if defined?(ActiveResource)
         ActiveResource::Base.send(:include, ActiveResourceApiAuth)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,13 +1,6 @@
 $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
 $LOAD_PATH.unshift(File.dirname(__FILE__))
 require 'rspec'
-require 'api_auth'
-require 'amatch'
-require 'rest_client'
-require 'curb'
-require 'httpi'
-require 'faraday'
-require 'net/http/post/multipart'
 
 require 'active_support'
 require 'active_support/test_case'
@@ -15,6 +8,14 @@ require 'action_controller'
 require 'action_controller/test_case'
 require 'active_resource'
 require 'active_resource/http_mock'
+
+require 'api_auth'
+require 'amatch'
+require 'rest_client'
+require 'curb'
+require 'httpi'
+require 'faraday'
+require 'net/http/post/multipart'
 
 # Requires supporting files with custom matchers and macros, etc,
 # in ./support/ and its subdirectories.


### PR DESCRIPTION
Hi. I'm using api_auth in a rack/activerecord app, but I don't want to load any other bits of rails if at all possible. The `api_auth/railtie` forces a bunch of things to be loaded that I don't want. I think it's fair to skip all that if Rails isn't even defined. What do you think?