### PR TITLE
Changing the default canonical string value as mentioned in the READM…

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,9 @@ content-MD5 are not present, then a blank string is used in their place. If the
 timestamp isn't present, a valid HTTP date is automatically added to the
 request. The canonical string is computed as follows:
 
-    canonical_string = 'http method,content-type,content-MD5,request URI,timestamp'
+    canonical_string = 'content-type,content-MD5,request URI,timestamp' which is the default value
+    or
+    canonical_string = 'http method,content-type,content-MD5,request URI,timestamp' if with_http_method is set to true
 
 2. This string is then used to create the signature which is a Base64 encoded
 SHA1 HMAC, using the client's private secret key.


### PR DESCRIPTION
Had issues with this piece of information missing from the README , had authentication issue because of difference in hash(betwen my client that uses api-auth and server that uses a different hmac library in java) with the api i was trying to hit written in java that uses hmac on the canonical string following the instructions in how it works section. 