### PR TITLE
Reflect ActiveRestClient's deprecation

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,13 +143,13 @@ single configuration line:
 
 This will automatically sign all outgoing ActiveResource requests from your app.
 
-### Active Rest Client
+### Flexirest
 
-ApiAuth also works with [ActiveRestClient](https://github.com/whichdigital/active-rest-client) in a very similar way.
-Simply add this configuration to your ActiveRestClient initializer in your app and it will automatically sign all outgoing requests.
+ApiAuth also works with [Flexirest](https://github.com/andyjeffries/flexirest) (used to be ActiveRestClient, but that is now unsupported) in a very similar way.
+Simply add this configuration to your Flexirest initializer in your app and it will automatically sign all outgoing requests.
 
 ``` ruby
-ActiveRestClient::Base.api_auth_credentials(@access_id, @secret_key)
+Flexirest::Base.api_auth_credentials(@access_id, @secret_key)
 ```
 
 ## Server


### PR DESCRIPTION
Thank you for having documentation pointing to ActiveRestClient.  Unfortunately, the owners of the ActiveRestClient repository stopped supporting it about 8 months ago, so I forked it (I was the original author of most of the codebase) and am now supporting it under the name "Flexirest".

https://github.com/andyjeffries/flexirest/blob/master/Migrating-from-ActiveRestClient.md

I've updated the README to reflect this so users don't keep using ActiveRestClient.