### PR TITLE
Configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,56 @@ configuration for your Ruby VM. To install:
 
 Please note the dash in the name versus the underscore.
 
+## Configuration
+
+The gem accepts some configuration options, if you would like more fine-grained control of how your requests are signed.
+
+``` ruby
+ApiAuth.configure do |config|
+  # Name of the header containing the request timestamp  
+  config.date_header = 'DATE'
+  # Format of the datetime string in the request timestamp header
+  config.date_format = '%a, %d %b %Y %T GMT'
+  # The name of the algorithm to pass at the beginning of the Authorization header
+  config.algorithm = 'APIAuth'
+  # A custom class to use to generate the Authorization header
+  config.auth_header_factory = ApiAuth::AuthHeaderFactories::Standard
+  # If using a custom auth header factory, you must redefined the auth_header_pattern so that 
+  # the auth header can be parsed properly
+  config.auth_header_pattern = /#{@algorithm}(?:-HMAC-(MD[245]|SHA(?:1|224|256|384|512)*))? ([^:]+):(.+)$/
+  # A custom class to use to generate the canonical string
+  config.canonical_string_factory = ApiAuth::CanonicalStringFactories::Standard
+  # A custom class to use to generate the signature
+  config.signer = ApiAuth::Signers::Standard
+end
+```
+
+### Auth Header Factory
+
+An Auth Header Factory must implement the class method `auth_header`. See [AuthHeaderFactories::Standard](lib/api_auth/auth_header_factories/standard.rb) for an example.
+
+When using a custom Auth Header Factory, you must also set the `auth_header_pattern` configuration variable. It requires three capture groups:
+
+1. The hash function used to generate the signature
+2. The Access ID
+3. The Generated Signature
+
+For example, if your Auth Header Factory returns the following auth header:
+
+`CoolAuth-SHA1 ID:1234,Signature=foobar`
+
+Then your `auth_header_pattern` should be set to
+
+`/CoolAuth(?:-(MD[245]|SHA(?:1|224|256|384|512)*))? ID:([^:]+),Signature=(.+)$/`
+
+### Canonical String Factory
+
+A Canonical String Factory must implement the class method `canonical_string`. See [CanonicalStringFactories::Standard](lib/api_auth/canonical_string_factories/standard.rb) for an example.
+
+### Signer
+
+A Signer must implement the class method `sign`. See [Signers::Standard](lib/api_auth/signers/standard.rb) for an example.
+
 ## Clients
 
 ApiAuth supports many popular HTTP clients. Support for other clients can be

--- a/lib/api_auth.rb
+++ b/lib/api_auth.rb
@@ -1,9 +1,15 @@
 require 'openssl'
 require 'base64'
 
+require 'api_auth/auth_header_factories/standard'
+require 'api_auth/canonical_string_factories/standard'
+require 'api_auth/signers/standard'
+
+require 'api_auth/configuration'
 require 'api_auth/errors'
 require 'api_auth/helpers'
 
+require 'api_auth/request_drivers/base'
 require 'api_auth/request_drivers/net_http'
 require 'api_auth/request_drivers/curb'
 require 'api_auth/request_drivers/rest_client'

--- a/lib/api_auth/auth_header_factories/standard.rb
+++ b/lib/api_auth/auth_header_factories/standard.rb
@@ -1,0 +1,10 @@
+module ApiAuth
+  module AuthHeaderFactories
+    class Standard # :nodoc:
+      def self.auth_header(_headers, access_id, options, signature)
+        hmac_string = "-HMAC-#{options[:digest].upcase}" unless options[:digest] == 'sha1'
+        "#{ApiAuth.configuration.algorithm}#{hmac_string} #{access_id}:#{signature}"
+      end
+    end
+  end
+end

--- a/lib/api_auth/base.rb
+++ b/lib/api_auth/base.rb
@@ -69,12 +69,12 @@ module ApiAuth
 
     private
 
-    AUTH_HEADER_PATTERN = /APIAuth(?:-HMAC-(MD[245]|SHA(?:1|224|256|384|512)*))? ([^:]+):(.+)$/
-
     def request_too_old?(headers)
       # 900 seconds is 15 minutes
 
-      Time.httpdate(headers.timestamp).utc < (Time.now.utc - 900)
+      timestamp = DateTime.strptime(headers.timestamp, ApiAuth.configuration.date_format)
+      time = Time.local(timestamp.year, timestamp.month, timestamp.day, timestamp.hour, timestamp.min, timestamp.sec)
+      time.utc < (Time.now.utc - 900)
     rescue ArgumentError
       true
     end
@@ -91,22 +91,30 @@ module ApiAuth
       header_sig = match_data[3]
       calculated_sig = hmac_signature(headers, secret_key, options)
 
-      header_sig == calculated_sig
+      secure_compare(header_sig, calculated_sig)
     end
 
     def hmac_signature(headers, secret_key, options)
-      canonical_string = headers.canonical_string(options[:override_http_method])
-      digest = OpenSSL::Digest.new(options[:digest])
-      b64_encode(OpenSSL::HMAC.digest(digest, secret_key, canonical_string))
+      ApiAuth.configuration.signer.sign(headers, secret_key, options)
     end
 
     def auth_header(headers, access_id, secret_key, options)
-      hmac_string = "-HMAC-#{options[:digest].upcase}" unless options[:digest] == 'sha1'
-      "APIAuth#{hmac_string} #{access_id}:#{hmac_signature(headers, secret_key, options)}"
+      ApiAuth.configuration.auth_header_factory.auth_header(headers, access_id, options, hmac_signature(headers, secret_key, options))
     end
 
     def parse_auth_header(auth_header)
-      AUTH_HEADER_PATTERN.match(auth_header)
+      ApiAuth.configuration.auth_header_pattern.match(auth_header)
+    end
+
+    # Copy of ActiveSupport::SecurityUtils.secure_compare from Rails 4.2.0
+    def secure_compare(a, b)
+      return false unless a.bytesize == b.bytesize
+
+      l = a.unpack "C#{a.bytesize}"
+
+      res = 0
+      b.each_byte { |byte| res |= byte ^ l.shift }
+      res == 0
     end
   end # class methods
 end # ApiAuth

--- a/lib/api_auth/canonical_string_factories/standard.rb
+++ b/lib/api_auth/canonical_string_factories/standard.rb
@@ -1,0 +1,24 @@
+module ApiAuth
+  module CanonicalStringFactories
+    class Standard # :nodoc:
+      class << self
+        def canonical_string(request, request_method)
+          [request_method.upcase,
+           request.content_type,
+           request.content_md5,
+           parse_uri(request.request_uri),
+           request.timestamp
+          ].join(',')
+        end
+
+        URI_WITHOUT_HOST_REGEXP = %r{https?://[^,?/]*}
+
+        def parse_uri(uri)
+          uri_without_host = uri.gsub(URI_WITHOUT_HOST_REGEXP, '')
+          return '/' if uri_without_host.empty?
+          uri_without_host
+        end
+      end
+    end
+  end
+end

--- a/lib/api_auth/configuration.rb
+++ b/lib/api_auth/configuration.rb
@@ -1,0 +1,26 @@
+module ApiAuth # :nodoc:
+  class << self
+    attr_accessor :configuration
+  end
+
+  def self.configure
+    self.configuration ||= Configuration.new
+    yield(configuration) if block_given?
+  end
+
+  class Configuration # :nodoc:
+    attr_accessor :date_header, :date_format, :algorithm, :auth_header_factory,
+                  :canonical_string_factory, :signer, :auth_header_pattern
+
+    def initialize
+      @date_header = 'DATE'
+      @date_format = '%a, %d %b %Y %T GMT'
+      @algorithm = 'APIAuth'
+      @auth_header_pattern = /#{@algorithm}(?:-HMAC-(MD[245]|SHA(?:1|224|256|384|512)*))? ([^:]+):(.+)$/
+      @auth_header_factory = ApiAuth::AuthHeaderFactories::Standard
+      @canonical_string_factory = ApiAuth::CanonicalStringFactories::Standard
+      @signer = ApiAuth::Signers::Standard
+    end
+  end
+end
+ApiAuth.configure

--- a/lib/api_auth/headers.rb
+++ b/lib/api_auth/headers.rb
@@ -54,12 +54,7 @@ module ApiAuth
         raise ArgumentError, 'unable to determine the http method from the request, please supply an override'
       end
 
-      [request_method.upcase,
-       @request.content_type,
-       @request.content_md5,
-       parse_uri(@request.request_uri),
-       @request.timestamp
-      ].join(',')
+      ApiAuth.configuration.canonical_string_factory.canonical_string(@request, request_method)
     end
 
     # Returns the authorization header from the request's headers
@@ -92,14 +87,8 @@ module ApiAuth
       @request.set_auth_header header
     end
 
-    private
-
-    URI_WITHOUT_HOST_REGEXP = %r{https?://[^,?/]*}
-
-    def parse_uri(uri)
-      uri_without_host = uri.gsub(URI_WITHOUT_HOST_REGEXP, '')
-      return '/' if uri_without_host.empty?
-      uri_without_host
+    def http_headers
+      @request.headers
     end
   end
 end

--- a/lib/api_auth/railtie.rb
+++ b/lib/api_auth/railtie.rb
@@ -77,7 +77,7 @@ module ApiAuth
             tmp.body = arguments[0] if arguments.length > 1
             ApiAuth.sign!(tmp, hmac_access_id, hmac_secret_key, api_auth_options)
             arguments.last['Content-MD5'] = tmp['Content-MD5'] if tmp['Content-MD5']
-            arguments.last['DATE'] = tmp['DATE']
+            arguments.last[ApiAuth.configuration.date_header] = tmp[ApiAuth.configuration.date_header]
             arguments.last['Authorization'] = tmp['Authorization']
           end
 

--- a/lib/api_auth/request_drivers/base.rb
+++ b/lib/api_auth/request_drivers/base.rb
@@ -1,0 +1,31 @@
+module ApiAuth
+  module RequestDrivers # :nodoc:
+    class Base # :nodoc:
+      include ApiAuth::Helpers
+
+      def initialize(request)
+        @request = request
+        fetch_headers
+        true
+      end
+
+      def authorization_header
+        find_header %w(Authorization HTTP_AUTHORIZATION)
+      end
+
+      def fetch_headers
+        raise NotImplementedError
+      end
+
+      def headers
+        @headers
+      end
+
+      protected
+
+      def find_header(keys)
+        keys.map { |key| @headers[key] || @headers[key.upcase] || @headers[key.downcase] }.compact.first
+      end
+    end
+  end
+end

--- a/lib/api_auth/request_drivers/curb.rb
+++ b/lib/api_auth/request_drivers/curb.rb
@@ -1,13 +1,6 @@
 module ApiAuth
   module RequestDrivers # :nodoc:
-    class CurbRequest # :nodoc:
-      include ApiAuth::Helpers
-
-      def initialize(request)
-        @request = request
-        fetch_headers
-        true
-      end
+    class CurbRequest < Base # :nodoc:
 
       def set_auth_header(header)
         @request.headers['Authorization'] = header
@@ -46,23 +39,19 @@ module ApiAuth
       end
 
       def set_date
-        @request.headers['DATE'] = Time.now.utc.httpdate
+        @request.headers[ApiAuth.configuration.date_header] = Time.now.utc.strftime(ApiAuth.configuration.date_format)
         fetch_headers
       end
 
       def timestamp
-        value = find_header(%w(DATE HTTP_DATE))
+        value = find_header([ApiAuth.configuration.date_header, "HTTP_#{ApiAuth.configuration.date_header}"])
         value.nil? ? '' : value
       end
 
-      def authorization_header
-        find_header %w(Authorization AUTHORIZATION HTTP_AUTHORIZATION)
-      end
-
-      private
+      protected
 
       def find_header(keys)
-        keys.map { |key| @headers[key] }.compact.first
+        keys.map { |key| @headers[key] || @headers[key.upcase] }.compact.first
       end
     end
   end

--- a/lib/api_auth/request_drivers/faraday.rb
+++ b/lib/api_auth/request_drivers/faraday.rb
@@ -1,13 +1,6 @@
 module ApiAuth
   module RequestDrivers # :nodoc:
-    class FaradayRequest # :nodoc:
-      include ApiAuth::Helpers
-
-      def initialize(request)
-        @request = request
-        fetch_headers
-        true
-      end
+    class FaradayRequest < Base # :nodoc:
 
       def set_auth_header(header)
         @request.headers['Authorization'] = header
@@ -61,23 +54,13 @@ module ApiAuth
       end
 
       def set_date
-        @request.headers['DATE'] = Time.now.utc.httpdate
+        @request.headers[ApiAuth.configuration.date_header] = Time.now.utc.strftime(ApiAuth.configuration.date_format)
         fetch_headers
       end
 
       def timestamp
-        value = find_header(%w(DATE HTTP_DATE))
+        value = find_header([ApiAuth.configuration.date_header, "HTTP_#{ApiAuth.configuration.date_header}"])
         value.nil? ? '' : value
-      end
-
-      def authorization_header
-        find_header %w(Authorization AUTHORIZATION HTTP_AUTHORIZATION)
-      end
-
-      private
-
-      def find_header(keys)
-        keys.map { |key| @headers[key] }.compact.first
       end
     end
   end

--- a/lib/api_auth/request_drivers/httpi.rb
+++ b/lib/api_auth/request_drivers/httpi.rb
@@ -1,13 +1,6 @@
 module ApiAuth
   module RequestDrivers # :nodoc:
-    class HttpiRequest # :nodoc:
-      include ApiAuth::Helpers
-
-      def initialize(request)
-        @request = request
-        fetch_headers
-        true
-      end
+    class HttpiRequest < Base # :nodoc:
 
       def set_auth_header(header)
         @request.headers['Authorization'] = header
@@ -57,23 +50,13 @@ module ApiAuth
       end
 
       def set_date
-        @request.headers['DATE'] = Time.now.utc.httpdate
+        @request.headers[ApiAuth.configuration.date_header] = Time.now.utc.strftime(ApiAuth.configuration.date_format)
         fetch_headers
       end
 
       def timestamp
-        value = find_header(%w(DATE HTTP_DATE))
+        value = find_header([ApiAuth.configuration.date_header, "HTTP_#{ApiAuth.configuration.date_header}"])
         value.nil? ? '' : value
-      end
-
-      def authorization_header
-        find_header %w(Authorization AUTHORIZATION HTTP_AUTHORIZATION)
-      end
-
-      private
-
-      def find_header(keys)
-        keys.map { |key| @headers[key] }.compact.first
       end
     end
   end

--- a/lib/api_auth/request_drivers/net_http.rb
+++ b/lib/api_auth/request_drivers/net_http.rb
@@ -1,17 +1,10 @@
 module ApiAuth
   module RequestDrivers # :nodoc:
-    class NetHttpRequest # :nodoc:
-      include ApiAuth::Helpers
-
-      def initialize(request)
-        @request = request
-        @headers = fetch_headers
-        true
-      end
+    class NetHttpRequest < Base # :nodoc:
 
       def set_auth_header(header)
         @request['Authorization'] = header
-        @headers = fetch_headers
+        fetch_headers
         @request
       end
 
@@ -29,6 +22,7 @@ module ApiAuth
       def populate_content_md5
         if @request.class::REQUEST_HAS_BODY
           @request['Content-MD5'] = calculated_md5
+          fetch_headers
         end
       end
 
@@ -41,7 +35,8 @@ module ApiAuth
       end
 
       def fetch_headers
-        @request
+        @headers = {}
+        @request.to_hash.map { |key, value| @headers[key] = value[0] }
       end
 
       def http_method
@@ -63,22 +58,13 @@ module ApiAuth
       end
 
       def set_date
-        @request['DATE'] = Time.now.utc.httpdate
+        @request[ApiAuth.configuration.date_header] = Time.now.utc.strftime(ApiAuth.configuration.date_format)
+        fetch_headers
       end
 
       def timestamp
-        value = find_header(%w(DATE HTTP_DATE))
+        value = find_header([ApiAuth.configuration.date_header, "HTTP_#{ApiAuth.configuration.date_header}"])
         value.nil? ? '' : value
-      end
-
-      def authorization_header
-        find_header %w(Authorization AUTHORIZATION HTTP_AUTHORIZATION)
-      end
-
-      private
-
-      def find_header(keys)
-        keys.map { |key| @headers[key] }.compact.first
       end
     end
   end

--- a/lib/api_auth/request_drivers/rack.rb
+++ b/lib/api_auth/request_drivers/rack.rb
@@ -1,13 +1,6 @@
 module ApiAuth
   module RequestDrivers # :nodoc:
-    class RackRequest # :nodoc:
-      include ApiAuth::Helpers
-
-      def initialize(request)
-        @request = request
-        fetch_headers
-        true
-      end
+    class RackRequest < Base # :nodoc:
 
       def set_auth_header(header)
         @request.env['Authorization'] = header
@@ -63,23 +56,13 @@ module ApiAuth
       end
 
       def set_date
-        @request.env['DATE'] = Time.now.utc.httpdate
+        @request.env[ApiAuth.configuration.date_header] = Time.now.utc.strftime(ApiAuth.configuration.date_format)
         fetch_headers
       end
 
       def timestamp
-        value = find_header(%w(DATE HTTP_DATE))
+        value = find_header([ApiAuth.configuration.date_header, "HTTP_#{ApiAuth.configuration.date_header}"])
         value.nil? ? '' : value
-      end
-
-      def authorization_header
-        find_header %w(Authorization AUTHORIZATION HTTP_AUTHORIZATION)
-      end
-
-      private
-
-      def find_header(keys)
-        keys.map { |key| @headers[key] }.compact.first
       end
     end
   end

--- a/lib/api_auth/request_drivers/rest_client.rb
+++ b/lib/api_auth/request_drivers/rest_client.rb
@@ -3,14 +3,7 @@ module RestClient; class Request; attr_accessor :processed_headers; end; end
 
 module ApiAuth
   module RequestDrivers # :nodoc:
-    class RestClientRequest # :nodoc:
-      include ApiAuth::Helpers
-
-      def initialize(request)
-        @request = request
-        @headers = fetch_headers
-        true
-      end
+    class RestClientRequest < Base # :nodoc:
 
       def set_auth_header(header)
         @request.headers['Authorization'] = header
@@ -44,7 +37,7 @@ module ApiAuth
       end
 
       def fetch_headers
-        capitalize_keys @request.processed_headers
+        @headers = capitalize_keys @request.processed_headers
       end
 
       def http_method
@@ -66,28 +59,20 @@ module ApiAuth
       end
 
       def set_date
-        @request.headers['DATE'] = Time.now.utc.httpdate
+        @request.headers[ApiAuth.configuration.date_header] = Time.now.utc.strftime(ApiAuth.configuration.date_format)
         save_headers
       end
 
       def timestamp
-        value = find_header(%w(DATE HTTP_DATE))
+        value = find_header([ApiAuth.configuration.date_header, "HTTP_#{ApiAuth.configuration.date_header}"])
         value.nil? ? '' : value
-      end
-
-      def authorization_header
-        find_header %w(Authorization AUTHORIZATION HTTP_AUTHORIZATION)
       end
 
       private
 
-      def find_header(keys)
-        keys.map { |key| @headers[key] }.compact.first
-      end
-
       def save_headers
         @request.processed_headers = @request.make_headers(@request.headers)
-        @headers = fetch_headers
+        fetch_headers
       end
     end
   end

--- a/lib/api_auth/signers/standard.rb
+++ b/lib/api_auth/signers/standard.rb
@@ -1,0 +1,17 @@
+require 'api_auth/helpers'
+
+module ApiAuth
+  module Signers
+    class Standard # :nodoc:
+      class << self
+        include Helpers
+
+        def sign(headers, secret_key, options)
+          canonical_string = headers.canonical_string(options[:override_http_method])
+          digest = OpenSSL::Digest.new(options[:digest])
+          b64_encode(OpenSSL::HMAC.digest(digest, secret_key, canonical_string))
+        end
+      end
+    end
+  end
+end

--- a/spec/railtie_spec.rb
+++ b/spec/railtie_spec.rb
@@ -63,7 +63,7 @@ describe 'Rails integration' do
 
     it 'should permit a request with properly signed headers' do
       request = ActionController::TestRequest.new
-      request.env['DATE'] = Time.now.utc.httpdate
+      request.env[ApiAuth.configuration.date_header] = Time.now.utc.strftime(ApiAuth.configuration.date_format)
       ApiAuth.sign!(request, '1044', API_KEY_STORE['1044'])
       response = generated_response(request, :index)
       expect(response.code).to eq('200')
@@ -71,7 +71,7 @@ describe 'Rails integration' do
 
     it 'should forbid a request with properly signed headers but timestamp > 15 minutes' do
       request = ActionController::TestRequest.new
-      request.env['DATE'] = 'Mon, 23 Jan 1984 03:29:56 GMT'
+      request.env[ApiAuth.configuration.date_header] = 'Mon, 23 Jan 1984 03:29:56 GMT'
       ApiAuth.sign!(request, '1044', API_KEY_STORE['1044'])
       response = generated_response(request, :index)
       expect(response.code).to eq('401')
@@ -80,7 +80,7 @@ describe 'Rails integration' do
     it "should insert a DATE header in the request when one hasn't been specified" do
       request = ActionController::TestRequest.new
       ApiAuth.sign!(request, '1044', API_KEY_STORE['1044'])
-      expect(request.headers['DATE']).not_to be_nil
+      expect(request.headers[ApiAuth.configuration.date_header]).not_to be_nil
     end
 
     it 'should forbid an unsigned request to a protected controller action' do
@@ -91,7 +91,7 @@ describe 'Rails integration' do
 
     it 'should forbid a request with a bogus signature' do
       request = ActionController::TestRequest.new
-      request.env['Authorization'] = 'APIAuth bogus:bogus'
+      request.env['Authorization'] = "#{ApiAuth.configuration.algorithm} bogus:bogus"
       response = generated_response(request, :index)
       expect(response.code).to eq('401')
     end
@@ -116,9 +116,9 @@ describe 'Rails integration' do
       ActiveResource::HttpMock.respond_to do |mock|
         mock.get '/test_resources/1.xml',
                  {
-                   'Authorization' => 'APIAuth 1044:LZ1jujf3x1nnGR70/208WPXdUHw=',
+                   'Authorization' => "#{ApiAuth.configuration.algorithm} 1044:LZ1jujf3x1nnGR70/208WPXdUHw=",
                    'Accept' => 'application/xml',
-                   'DATE' => 'Mon, 23 Jan 1984 03:29:56 GMT'
+                   ApiAuth.configuration.date_header => timestamp.strftime(ApiAuth.configuration.date_format)
                  },
                  { :id => '1' }.to_xml(:root => 'test_resource')
       end

--- a/spec/request_drivers/action_controller_spec.rb
+++ b/spec/request_drivers/action_controller_spec.rb
@@ -3,18 +3,18 @@ require 'spec_helper'
 if defined?(ActionController::Request)
 
   describe ApiAuth::RequestDrivers::ActionControllerRequest do
-    let(:timestamp) { Time.now.utc.httpdate }
+    let(:timestamp) { Time.now.utc.strftime(ApiAuth.configuration.date_format) }
 
     let(:request) do
       ActionController::Request.new(
-        'AUTHORIZATION' => 'APIAuth 1044:12345',
+        'AUTHORIZATION' => "#{ApiAuth.configuration.algorithm} 1044:12345",
         'PATH_INFO' => '/resource.xml',
         'QUERY_STRING' => 'foo=bar&bar=foo',
         'REQUEST_METHOD' => 'PUT',
         'CONTENT_MD5' => '1B2M2Y8AsgTpgAmY7PhCfg==',
         'CONTENT_TYPE' => 'text/plain',
         'CONTENT_LENGTH' => '11',
-        'HTTP_DATE' => timestamp,
+        "HTTP_#{ApiAuth.configuration.date_header}" => timestamp,
         'rack.input' => StringIO.new("hello\nworld")
       )
     end
@@ -39,7 +39,7 @@ if defined?(ActionController::Request)
       end
 
       it 'gets the authorization_header' do
-        expect(driven_request.authorization_header).to eq('APIAuth 1044:12345')
+        expect(driven_request.authorization_header).to eq("#{ApiAuth.configuration.algorithm} 1044:12345")
       end
 
       describe '#calculated_md5' do
@@ -135,12 +135,12 @@ if defined?(ActionController::Request)
 
       describe '#set_date' do
         before do
-          allow(Time).to receive_message_chain(:now, :utc, :httpdate).and_return(timestamp)
+          allow(Time).to receive_message_chain(:now, :utc, :strftime).and_return(timestamp)
         end
 
         it 'sets the date header of the request' do
           driven_request.set_date
-          expect(request.env['HTTP_DATE']).to eq(timestamp)
+          expect(request.env["HTTP_#{ApiAuth.configuration.date_header}"]).to eq(timestamp)
         end
 
         it 'refreshes the cached headers' do
@@ -151,8 +151,8 @@ if defined?(ActionController::Request)
 
       describe '#set_auth_header' do
         it 'sets the auth header' do
-          driven_request.set_auth_header('APIAuth 1044:54321')
-          expect(request.env['Authorization']).to eq('APIAuth 1044:54321')
+          driven_request.set_auth_header("#{ApiAuth.configuration.algorithm} 1044:54321")
+          expect(request.env['Authorization']).to eq("#{ApiAuth.configuration.algorithm} 1044:54321")
         end
       end
     end

--- a/spec/request_drivers/action_dispatch_spec.rb
+++ b/spec/request_drivers/action_dispatch_spec.rb
@@ -3,19 +3,19 @@ require 'spec_helper'
 if defined?(ActionDispatch::Request)
 
   describe ApiAuth::RequestDrivers::ActionDispatchRequest do
-    let(:timestamp) { Time.now.utc.httpdate }
+    let(:timestamp) { Time.now.utc.strftime(ApiAuth.configuration.date_format) }
 
     let(:request) do
       ActionDispatch::Request.new(
-        'AUTHORIZATION'  => 'APIAuth 1044:12345',
-        'PATH_INFO'      => '/resource.xml',
-        'QUERY_STRING'   => 'foo=bar&bar=foo',
+        'AUTHORIZATION' => "#{ApiAuth.configuration.algorithm} 1044:12345",
+        'PATH_INFO' => '/resource.xml',
+        'QUERY_STRING' => 'foo=bar&bar=foo',
         'REQUEST_METHOD' => 'PUT',
-        'CONTENT_MD5'    => '1B2M2Y8AsgTpgAmY7PhCfg==',
-        'CONTENT_TYPE'   => 'text/plain',
+        'CONTENT_MD5' => '1B2M2Y8AsgTpgAmY7PhCfg==',
+        'CONTENT_TYPE' => 'text/plain',
         'CONTENT_LENGTH' => '11',
-        'HTTP_DATE'      => timestamp,
-        'rack.input'     => StringIO.new("hello\nworld")
+        "HTTP_#{ApiAuth.configuration.date_header}" => timestamp,
+        'rack.input' => StringIO.new("hello\nworld")
       )
     end
 
@@ -39,7 +39,7 @@ if defined?(ActionDispatch::Request)
       end
 
       it 'gets the authorization_header' do
-        expect(driven_request.authorization_header).to eq('APIAuth 1044:12345')
+        expect(driven_request.authorization_header).to eq("#{ApiAuth.configuration.algorithm} 1044:12345")
       end
 
       describe '#calculated_md5' do
@@ -135,12 +135,12 @@ if defined?(ActionDispatch::Request)
 
       describe '#set_date' do
         before do
-          allow(Time).to receive_message_chain(:now, :utc, :httpdate).and_return(timestamp)
+          allow(Time).to receive_message_chain(:now, :utc, :strftime).and_return(timestamp)
         end
 
         it 'sets the date header of the request' do
           driven_request.set_date
-          expect(request.env['HTTP_DATE']).to eq(timestamp)
+          expect(request.env["HTTP_#{ApiAuth.configuration.date_header}"]).to eq(timestamp)
         end
 
         it 'refreshes the cached headers' do
@@ -151,8 +151,8 @@ if defined?(ActionDispatch::Request)
 
       describe '#set_auth_header' do
         it 'sets the auth header' do
-          driven_request.set_auth_header('APIAuth 1044:54321')
-          expect(request.env['Authorization']).to eq('APIAuth 1044:54321')
+          driven_request.set_auth_header("#{ApiAuth.configuration.algorithm} 1044:54321")
+          expect(request.env['Authorization']).to eq("#{ApiAuth.configuration.algorithm} 1044:54321")
         end
       end
     end

--- a/spec/request_drivers/curb_spec.rb
+++ b/spec/request_drivers/curb_spec.rb
@@ -1,14 +1,14 @@
 require 'spec_helper'
 
 describe ApiAuth::RequestDrivers::CurbRequest do
-  let(:timestamp) { Time.now.utc.httpdate }
+  let(:timestamp) { Time.now.utc.strftime(ApiAuth.configuration.date_format) }
 
   let(:request) do
     headers = {
-      'Authorization' => 'APIAuth 1044:12345',
-      'Content-MD5'   => '1B2M2Y8AsgTpgAmY7PhCfg==',
-      'Content-Type'  => 'text/plain',
-      'Date'          => timestamp
+      'Authorization' => "#{ApiAuth.configuration.algorithm} 1044:12345",
+      'Content-MD5' => '1B2M2Y8AsgTpgAmY7PhCfg==',
+      'Content-Type' => 'text/plain',
+      ApiAuth.configuration.date_header => timestamp
     }
     Curl::Easy.new('/resource.xml?foo=bar&bar=foo') do |curl|
       curl.headers = headers
@@ -35,7 +35,7 @@ describe ApiAuth::RequestDrivers::CurbRequest do
     end
 
     it 'gets the authorization_header' do
-      expect(driven_request.authorization_header).to eq('APIAuth 1044:12345')
+      expect(driven_request.authorization_header).to eq("#{ApiAuth.configuration.algorithm} 1044:12345")
     end
 
     describe 'http_method' do
@@ -64,12 +64,12 @@ describe ApiAuth::RequestDrivers::CurbRequest do
 
     describe '#set_date' do
       before do
-        allow(Time).to receive_message_chain(:now, :utc, :httpdate).and_return(timestamp)
+        allow(Time).to receive_message_chain(:now, :utc, :strftime).and_return(timestamp)
       end
 
       it 'sets the date header of the request' do
         driven_request.set_date
-        expect(request.headers['DATE']).to eq(timestamp)
+        expect(request.headers[ApiAuth.configuration.date_header]).to eq(timestamp)
       end
 
       it 'refreshes the cached headers' do
@@ -80,8 +80,8 @@ describe ApiAuth::RequestDrivers::CurbRequest do
 
     describe '#set_auth_header' do
       it 'sets the auth header' do
-        driven_request.set_auth_header('APIAuth 1044:54321')
-        expect(request.headers['Authorization']).to eq('APIAuth 1044:54321')
+        driven_request.set_auth_header("#{ApiAuth.configuration.algorithm} 1044:54321")
+        expect(request.headers['Authorization']).to eq("#{ApiAuth.configuration.algorithm} 1044:54321")
       end
     end
   end

--- a/spec/request_drivers/faraday_spec.rb
+++ b/spec/request_drivers/faraday_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe ApiAuth::RequestDrivers::FaradayRequest do
-  let(:timestamp) { Time.now.utc.httpdate }
+  let(:timestamp) { Time.now.utc.strftime(ApiAuth.configuration.date_format) }
 
   let(:faraday_stubs) do
     Faraday::Adapter::Test::Stubs.new do |stub|
@@ -19,10 +19,10 @@ describe ApiAuth::RequestDrivers::FaradayRequest do
 
   let(:request_headers) do
     {
-      'Authorization' => 'APIAuth 1044:12345',
+      'Authorization' => "#{ApiAuth.configuration.algorithm} 1044:12345",
       'Content-MD5' => '1B2M2Y8AsgTpgAmY7PhCfg==',
       'content-type' => 'text/plain',
-      'DATE' => timestamp
+      ApiAuth.configuration.date_header => timestamp
     }
   end
 
@@ -57,7 +57,7 @@ describe ApiAuth::RequestDrivers::FaradayRequest do
     end
 
     it 'gets the authorization_header' do
-      expect(driven_request.authorization_header).to eq('APIAuth 1044:12345')
+      expect(driven_request.authorization_header).to eq("#{ApiAuth.configuration.algorithm} 1044:12345")
     end
 
     describe '#calculated_md5' do
@@ -161,12 +161,12 @@ describe ApiAuth::RequestDrivers::FaradayRequest do
 
     describe '#set_date' do
       before do
-        allow(Time).to receive_message_chain(:now, :utc, :httpdate).and_return(timestamp)
+        allow(Time).to receive_message_chain(:now, :utc, :strftime).and_return(timestamp)
       end
 
       it 'sets the date header of the request' do
         driven_request.set_date
-        expect(request.headers['DATE']).to eq(timestamp)
+        expect(request.headers[ApiAuth.configuration.date_header]).to eq(timestamp)
       end
 
       it 'refreshes the cached headers' do
@@ -177,8 +177,8 @@ describe ApiAuth::RequestDrivers::FaradayRequest do
 
     describe '#set_auth_header' do
       it 'sets the auth header' do
-        driven_request.set_auth_header('APIAuth 1044:54321')
-        expect(request.headers['Authorization']).to eq('APIAuth 1044:54321')
+        driven_request.set_auth_header("#{ApiAuth.configuration.algorithm} 1044:54321")
+        expect(request.headers['Authorization']).to eq("#{ApiAuth.configuration.algorithm} 1044:54321")
       end
     end
   end

--- a/spec/request_drivers/httpi_spec.rb
+++ b/spec/request_drivers/httpi_spec.rb
@@ -1,14 +1,14 @@
 require 'spec_helper'
 
 describe ApiAuth::RequestDrivers::HttpiRequest do
-  let(:timestamp) { Time.now.utc.httpdate }
+  let(:timestamp) { Time.now.utc.strftime(ApiAuth.configuration.date_format) }
 
   let(:request) do
     httpi_request = HTTPI::Request.new('http://localhost/resource.xml?foo=bar&bar=foo')
-    httpi_request.headers.merge!('Authorization' => 'APIAuth 1044:12345',
+    httpi_request.headers.merge!('Authorization' => "#{ApiAuth.configuration.algorithm} 1044:12345",
                                  'content-md5' => '1B2M2Y8AsgTpgAmY7PhCfg==',
                                  'content-type' => 'text/plain',
-                                 'date' => timestamp)
+                                 ApiAuth.configuration.date_header => timestamp)
     httpi_request.body = "hello\nworld"
     httpi_request
   end
@@ -33,7 +33,7 @@ describe ApiAuth::RequestDrivers::HttpiRequest do
     end
 
     it 'gets the authorization_header' do
-      expect(driven_request.authorization_header).to eq('APIAuth 1044:12345')
+      expect(driven_request.authorization_header).to eq("#{ApiAuth.configuration.algorithm} 1044:12345")
     end
 
     describe '#calculated_md5' do
@@ -92,12 +92,12 @@ describe ApiAuth::RequestDrivers::HttpiRequest do
 
     describe '#set_date' do
       before do
-        allow(Time).to receive_message_chain(:now, :utc, :httpdate).and_return(timestamp)
+        allow(Time).to receive_message_chain(:now, :utc, :strftime).and_return(timestamp)
       end
 
       it 'sets the date header of the request' do
         driven_request.set_date
-        expect(request.headers['DATE']).to eq(timestamp)
+        expect(request.headers[ApiAuth.configuration.date_header]).to eq(timestamp)
       end
 
       it 'refreshes the cached headers' do
@@ -108,8 +108,8 @@ describe ApiAuth::RequestDrivers::HttpiRequest do
 
     describe '#set_auth_header' do
       it 'sets the auth header' do
-        driven_request.set_auth_header('APIAuth 1044:54321')
-        expect(request.headers['Authorization']).to eq('APIAuth 1044:54321')
+        driven_request.set_auth_header("#{ApiAuth.configuration.algorithm} 1044:54321")
+        expect(request.headers['Authorization']).to eq("#{ApiAuth.configuration.algorithm} 1044:54321")
       end
     end
   end

--- a/spec/request_drivers/net_http_spec.rb
+++ b/spec/request_drivers/net_http_spec.rb
@@ -1,16 +1,16 @@
 require 'spec_helper'
 
 describe ApiAuth::RequestDrivers::NetHttpRequest do
-  let(:timestamp) { Time.now.utc.httpdate }
+  let(:timestamp) { Time.now.utc.strftime(ApiAuth.configuration.date_format) }
 
   let(:request_path) { '/resource.xml?foo=bar&bar=foo' }
 
   let(:request_headers) do
     {
-      'Authorization' => 'APIAuth 1044:12345',
+      'Authorization' => "#{ApiAuth.configuration.algorithm} 1044:12345",
       'content-md5' => '1B2M2Y8AsgTpgAmY7PhCfg==',
       'content-type' => 'text/plain',
-      'date' => timestamp
+      ApiAuth.configuration.date_header => timestamp
     }
   end
 
@@ -49,7 +49,7 @@ describe ApiAuth::RequestDrivers::NetHttpRequest do
     end
 
     it 'gets the authorization_header' do
-      expect(driven_request.authorization_header).to eq('APIAuth 1044:12345')
+      expect(driven_request.authorization_header).to eq("#{ApiAuth.configuration.algorithm} 1044:12345")
     end
 
     describe '#calculated_md5' do
@@ -132,12 +132,12 @@ describe ApiAuth::RequestDrivers::NetHttpRequest do
 
     describe '#set_date' do
       before do
-        allow(Time).to receive_message_chain(:now, :utc, :httpdate).and_return(timestamp)
+        allow(Time).to receive_message_chain(:now, :utc, :strftime).and_return(timestamp)
       end
 
       it 'sets the date header of the request' do
         driven_request.set_date
-        expect(request['DATE']).to eq(timestamp)
+        expect(request[ApiAuth.configuration.date_header]).to eq(timestamp)
       end
 
       it 'refreshes the cached headers' do
@@ -148,8 +148,8 @@ describe ApiAuth::RequestDrivers::NetHttpRequest do
 
     describe '#set_auth_header' do
       it 'sets the auth header' do
-        driven_request.set_auth_header('APIAuth 1044:54321')
-        expect(request['Authorization']).to eq('APIAuth 1044:54321')
+        driven_request.set_auth_header("#{ApiAuth.configuration.algorithm} 1044:54321")
+        expect(request['Authorization']).to eq("#{ApiAuth.configuration.algorithm} 1044:54321")
       end
     end
   end

--- a/spec/request_drivers/rack_spec.rb
+++ b/spec/request_drivers/rack_spec.rb
@@ -1,16 +1,16 @@
 require 'spec_helper'
 
 describe ApiAuth::RequestDrivers::RackRequest do
-  let(:timestamp) { Time.now.utc.httpdate }
+  let(:timestamp) { Time.now.utc.strftime(ApiAuth.configuration.date_format) }
 
   let(:request_path) { '/resource.xml?foo=bar&bar=foo' }
 
   let(:request_headers) do
     {
-      'Authorization' => 'APIAuth 1044:12345',
+      'Authorization' => "#{ApiAuth.configuration.algorithm} 1044:12345",
       'Content-MD5' => '1B2M2Y8AsgTpgAmY7PhCfg==',
       'Content-Type' => 'text/plain',
-      'Date' => timestamp
+      ApiAuth.configuration.date_header => timestamp
     }
   end
 
@@ -44,7 +44,7 @@ describe ApiAuth::RequestDrivers::RackRequest do
     end
 
     it 'gets the authorization_header' do
-      expect(driven_request.authorization_header).to eq('APIAuth 1044:12345')
+      expect(driven_request.authorization_header).to eq("#{ApiAuth.configuration.algorithm} 1044:12345")
     end
 
     describe '#calculated_md5' do
@@ -184,12 +184,12 @@ describe ApiAuth::RequestDrivers::RackRequest do
 
     describe '#set_date' do
       before do
-        allow(Time).to receive_message_chain(:now, :utc, :httpdate).and_return(timestamp)
+        allow(Time).to receive_message_chain(:now, :utc, :strftime).and_return(timestamp)
       end
 
       it 'sets the date header of the request' do
         driven_request.set_date
-        expect(request.env['DATE']).to eq(timestamp)
+        expect(request.env[ApiAuth.configuration.date_header]).to eq(timestamp)
       end
 
       it 'refreshes the cached headers' do
@@ -200,8 +200,8 @@ describe ApiAuth::RequestDrivers::RackRequest do
 
     describe '#set_auth_header' do
       it 'sets the auth header' do
-        driven_request.set_auth_header('APIAuth 1044:54321')
-        expect(request.env['Authorization']).to eq('APIAuth 1044:54321')
+        driven_request.set_auth_header("#{ApiAuth.configuration.algorithm} 1044:54321")
+        expect(request.env['Authorization']).to eq("#{ApiAuth.configuration.algorithm} 1044:54321")
       end
     end
   end

--- a/spec/request_drivers/rest_client_spec.rb
+++ b/spec/request_drivers/rest_client_spec.rb
@@ -1,16 +1,16 @@
 require 'spec_helper'
 
 describe ApiAuth::RequestDrivers::RestClientRequest do
-  let(:timestamp) { Time.now.utc.httpdate }
+  let(:timestamp) { Time.now.utc.strftime(ApiAuth.configuration.date_format) }
 
   let(:request_path) { '/resource.xml?foo=bar&bar=foo' }
 
   let(:request_headers) do
     {
-      'Authorization' => 'APIAuth 1044:12345',
+      'Authorization' => "#{ApiAuth.configuration.algorithm} 1044:12345",
       'Content-MD5' => '1B2M2Y8AsgTpgAmY7PhCfg==',
       'Content-Type' => 'text/plain',
-      'Date' => timestamp
+      ApiAuth.configuration.date_header => timestamp
     }
   end
 
@@ -43,7 +43,7 @@ describe ApiAuth::RequestDrivers::RestClientRequest do
     end
 
     it 'gets the authorization_header' do
-      expect(driven_request.authorization_header).to eq('APIAuth 1044:12345')
+      expect(driven_request.authorization_header).to eq("#{ApiAuth.configuration.algorithm} 1044:12345")
     end
 
     describe '#calculated_md5' do
@@ -176,13 +176,13 @@ describe ApiAuth::RequestDrivers::RestClientRequest do
 
     describe '#set_date' do
       before do
-        allow(Time).to receive_message_chain(:now, :utc, :httpdate).and_return(timestamp)
+        allow(Time).to receive_message_chain(:now, :utc, :strftime).and_return(timestamp)
       end
 
       it 'sets the date header of the request' do
-        allow(Time).to receive_message_chain(:now, :utc, :httpdate).and_return(timestamp)
+        allow(Time).to receive_message_chain(:now, :utc, :strftime).and_return(timestamp)
         driven_request.set_date
-        expect(request.headers['DATE']).to eq(timestamp)
+        expect(request.headers[ApiAuth.configuration.date_header]).to eq(timestamp)
       end
 
       it 'refreshes the cached headers' do
@@ -193,8 +193,8 @@ describe ApiAuth::RequestDrivers::RestClientRequest do
 
     describe '#set_auth_header' do
       it 'sets the auth header' do
-        driven_request.set_auth_header('APIAuth 1044:54321')
-        expect(request.headers['Authorization']).to eq('APIAuth 1044:54321')
+        driven_request.set_auth_header("#{ApiAuth.configuration.algorithm} 1044:54321")
+        expect(request.headers['Authorization']).to eq("#{ApiAuth.configuration.algorithm} 1044:54321")
       end
     end
   end
@@ -227,10 +227,10 @@ describe ApiAuth::RequestDrivers::RestClientRequest do
       context 'when calculated matches sent' do
         let(:request_headers) do
           {
-            'Authorization' => 'APIAuth 1044:12345',
+            'Authorization' => "#{ApiAuth.configuration.algorithm} 1044:12345",
             'Content-MD5' => 'kZXQvrKoieG+Be1rsZVINw==',
             'Content-Type' => 'text/plain',
-            'Date' => timestamp
+            ApiAuth.configuration.date_header => timestamp
           }
         end
 
@@ -242,10 +242,10 @@ describe ApiAuth::RequestDrivers::RestClientRequest do
       context "when calculated doesn't match sent" do
         let(:request_headers) do
           {
-            'Authorization' => 'APIAuth 1044:12345',
+            'Authorization' => "#{ApiAuth.configuration.algorithm} 1044:12345",
             'Content-MD5' => '3',
             'Content-Type' => 'text/plain',
-            'Date' => timestamp
+            ApiAuth.configuration.date_header => timestamp
           }
         end
 
@@ -268,10 +268,10 @@ describe ApiAuth::RequestDrivers::RestClientRequest do
       context 'when calculated matches sent' do
         let(:request_headers) do
           {
-            'Authorization' => 'APIAuth 1044:12345',
+            'Authorization' => "#{ApiAuth.configuration.algorithm} 1044:12345",
             'Content-MD5' => 'kZXQvrKoieG+Be1rsZVINw==',
             'Content-Type' => 'text/plain',
-            'Date' => timestamp
+            ApiAuth.configuration.date_header => timestamp
           }
         end
 
@@ -283,10 +283,10 @@ describe ApiAuth::RequestDrivers::RestClientRequest do
       context "when calculated doesn't match sent" do
         let(:request_headers) do
           {
-            'Authorization' => 'APIAuth 1044:12345',
+            'Authorization' => "#{ApiAuth.configuration.algorithm} 1044:12345",
             'Content-MD5' => '3',
             'Content-Type' => 'text/plain',
-            'Date' => timestamp
+            ApiAuth.configuration.date_header => timestamp
           }
         end
 
@@ -315,7 +315,7 @@ describe ApiAuth::RequestDrivers::RestClientRequest do
     it "doesn't mess up symbol based headers" do
       headers = { 'Content-MD5' => 'e59ff97941044f85df5297e1c302d260',
                   :content_type => 'text/plain',
-                  'Date' => 'Mon, 23 Jan 1984 03:29:56 GMT' }
+                  ApiAuth.configuration.date_header => 'Mon, 23 Jan 1984 03:29:56 GMT' }
       request = RestClient::Request.new(:url => '/resource.xml?foo=bar&bar=foo',
                                         :headers => headers,
                                         :method => :put)


### PR DESCRIPTION
This adds configuration for `api_auth`, which allows more flexibility in the construction of the Authorization header and the Signature. See `configuration.rb` or the `README` for the best overview of the changes.

Also, this uses the method `ActiveSupport::SecurityUtils.secure_compare` does to prevent a timing attack, as discussed in #56 
