### PR TITLE
Don't use #blank?

### DIFF
--- a/lib/api_auth/base.rb
+++ b/lib/api_auth/base.rb
@@ -83,7 +83,7 @@ module ApiAuth
       match_data = parse_auth_header(headers.authorization_header)
       return false unless match_data
 
-      digest = match_data[1].blank? ? 'SHA1' : match_data[1].upcase
+      digest = match_data[1].nil? ? 'SHA1' : match_data[1].upcase
       raise InvalidRequestDigest if !options[:digest].nil? && !options[:digest].casecmp(digest).zero?
 
       options = { :digest => digest }.merge(options)


### PR DESCRIPTION
The #blank? method is actually defined in activesupport which isn't a
runtime dependency of the gem. This is only ever going to be a string or
nil, so this check works the same way.