### PR TITLE
Fix header regex.

### DIFF
--- a/lib/api_auth/base.rb
+++ b/lib/api_auth/base.rb
@@ -69,7 +69,7 @@ module ApiAuth
 
     private
 
-    AUTH_HEADER_PATTERN = /APIAuth(?:-HMAC-(MD[245]|SHA(?:1|224|256|384|512)*))? ([^:]+):(.+)$/
+    AUTH_HEADER_PATTERN = /APIAuth(?:-HMAC-(MD[245]|SHA(?:1|224|256|384|512)?))? ([^:]+):(.+)$/
 
     def request_too_old?(headers)
       # 900 seconds is 15 minutes


### PR DESCRIPTION
The previous regex would match any number of instances of any of the
supported SHA formats, e.g. SHA111. Instead of matching any number, we
want to match optionally one.

Also added some tests that this rejects invalid digest formats.