### PR TITLE
Disallow request in the future.

### DIFF
--- a/lib/api_auth/base.rb
+++ b/lib/api_auth/base.rb
@@ -41,7 +41,7 @@ module ApiAuth
         false
       elsif !signatures_match?(headers, secret_key, options)
         false
-      elsif request_too_old?(headers)
+      elsif !check_request_date?(headers)
         false
       else
         true
@@ -71,10 +71,11 @@ module ApiAuth
 
     AUTH_HEADER_PATTERN = /APIAuth(?:-HMAC-(MD[245]|SHA(?:1|224|256|384|512)?))? ([^:]+):(.+)$/
 
-    def request_too_old?(headers)
+    def check_request_date?(headers)
       # 900 seconds is 15 minutes
 
-      Time.httpdate(headers.timestamp).utc < (Time.now.utc - 900)
+      Time.httpdate(headers.timestamp).utc > (Time.now.utc - 900) &&
+        Time.httpdate(headers.timestamp).utc < (Time.now.utc + 900)
     rescue ArgumentError
       true
     end

--- a/spec/railtie_spec.rb
+++ b/spec/railtie_spec.rb
@@ -77,6 +77,14 @@ describe 'Rails integration' do
       expect(response.code).to eq('401')
     end
 
+    it 'should forbid a request with properly signed headers but timestamp > 15 minutes' do
+      request = ActionController::TestRequest.new
+      request.env['DATE'] = 'Mon, 23 Jan 2100 03:29:56 GMT'
+      ApiAuth.sign!(request, '1044', API_KEY_STORE['1044'])
+      response = generated_response(request, :index)
+      expect(response.code).to eq('401')
+    end
+
     it "should insert a DATE header in the request when one hasn't been specified" do
       request = ActionController::TestRequest.new
       ApiAuth.sign!(request, '1044', API_KEY_STORE['1044'])


### PR DESCRIPTION
Currently we disallow requests on the past to block replay attack, but a request in the future is always valid. It seems to be good to have the same behaviour.