### PR TITLE
Return explicit reasons on bad authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,12 @@ To validate whether or not a request is authentic:
     ApiAuth.authentic?(signed_request, secret_key)
 ```
 
+To display the reasons to be authentic in a Ruby Hash, use the `authenticity_report` method:
+
+```ruby
+    ApiAuth.authenticity_report(signed_request, secret_key)
+```
+
 The `authentic?` method uses the digest specified in the `Authorization` header.
 For exemple SHA256 for:
 


### PR DESCRIPTION
I have one server with a time delay, but it was very complicate to understand and debug the issue in the application because ApiAuth return only false for bad authentication.

Let change that with explicit error.
