### PR TITLE
Fix Rails path mutation

### DIFF
--- a/lib/api_auth/request_drivers/action_dispatch.rb
+++ b/lib/api_auth/request_drivers/action_dispatch.rb
@@ -2,7 +2,7 @@ module ApiAuth
   module RequestDrivers # :nodoc:
     class ActionDispatchRequest < ActionControllerRequest # :nodoc:
       def request_uri
-        @request.fullpath
+        @request.original_fullpath
       end
     end
   end

--- a/spec/request_drivers/action_dispatch_spec.rb
+++ b/spec/request_drivers/action_dispatch_spec.rb
@@ -30,8 +30,29 @@ if defined?(ActionDispatch::Request)
         expect(driven_request.content_md5).to eq('1B2M2Y8AsgTpgAmY7PhCfg==')
       end
 
-      it 'gets the request_uri' do
-        expect(driven_request.request_uri).to eq('/resource.xml?foo=bar&bar=foo')
+      describe 'request_uri' do
+        context 'with url parameters' do
+          it 'gets the request_uri' do
+            expect(driven_request.request_uri).to eq('/resource.xml?foo=bar&bar=foo')
+          end
+        end
+
+        context 'with mutated path' do
+          let(:request) do
+            ActionDispatch::Request.new(
+              'PATH_INFO' => '/resource/',
+              'ORIGINAL_FULLPATH' => '/resource/'
+            )
+          end
+
+          before do
+            request.path_info = 'overwritten_in_action_dispatch'
+          end
+
+          it 'gets the original path' do
+            expect(driven_request.request_uri).to eq('/resource/')
+          end
+        end
       end
 
       it 'gets the timestamp' do


### PR DESCRIPTION
ActionDispatch will mutate the uri of a request before the application
actually gets a chance to see it. This can lead to auth failures where
the client signed with the original version of the path, and the server
is comparing against a mutated version.

Instead for ActionDispatch::Request we should use #original_fullpath,
which is passed to Rails from Rack.