### PR TITLE
add require 'time'

### DIFF
--- a/lib/api_auth/request_drivers/net_http.rb
+++ b/lib/api_auth/request_drivers/net_http.rb
@@ -1,3 +1,4 @@
+require 'time'
 module ApiAuth
   module RequestDrivers # :nodoc:
     class NetHttpRequest # :nodoc:


### PR DESCRIPTION
fixes NoMethodError: undefined method `httpdate' on line 65 (66 in this new version of the file)