### PR TITLE
retire MD2 and MD4

### DIFF
--- a/lib/api_auth/base.rb
+++ b/lib/api_auth/base.rb
@@ -69,7 +69,7 @@ module ApiAuth
 
     private
 
-    AUTH_HEADER_PATTERN = /APIAuth(?:-HMAC-(MD[245]|SHA(?:1|224|256|384|512)?))? ([^:]+):(.+)$/
+    AUTH_HEADER_PATTERN = /APIAuth(?:-HMAC-(MD5|SHA(?:1|224|256|384|512)?))? ([^:]+):(.+)$/
 
     def request_too_old?(headers)
       # 900 seconds is 15 minutes


### PR DESCRIPTION
[MD2 is retired](https://tools.ietf.org/html/rfc6149)
[MD4 is retired](https://tools.ietf.org/html/rfc6150)
[further argument against MD4](https://www.iacr.org/archive/crypto2007/46220013/46220013.pdf)

In particular the linked pdf demonstrates a key recovery attack against MD4. This is from '06 so the state of the art is likely advanced.