### PR TITLE
Add PATCH request type via copy-paste

### DIFF
--- a/lib/api_auth/request_drivers/action_controller.rb
+++ b/lib/api_auth/request_drivers/action_controller.rb
@@ -21,13 +21,13 @@ module ApiAuth
       end
 
       def populate_content_md5
-        return unless @request.put? || @request.post?
+        return unless @request.put? || @request.post? || @request.patch?
         @request.env['Content-MD5'] = calculated_md5
         fetch_headers
       end
 
       def md5_mismatch?
-        if @request.put? || @request.post?
+        if @request.put? || @request.post? || @request.patch?
           calculated_md5 != content_md5
         else
           false

--- a/lib/api_auth/request_drivers/action_controller.rb
+++ b/lib/api_auth/request_drivers/action_controller.rb
@@ -21,13 +21,13 @@ module ApiAuth
       end
 
       def populate_content_md5
-        return unless @request.put? || @request.post? || @request.patch?
+        return unless @request.put? || @request.post? || @request.respond_to?(:patch?) && @request.patch?
         @request.env['Content-MD5'] = calculated_md5
         fetch_headers
       end
 
       def md5_mismatch?
-        if @request.put? || @request.post? || @request.patch?
+        if @request.put? || @request.post? || @request.respond_to?(:patch?) && @request.patch?
           calculated_md5 != content_md5
         else
           false

--- a/lib/api_auth/request_drivers/faraday.rb
+++ b/lib/api_auth/request_drivers/faraday.rb
@@ -21,13 +21,13 @@ module ApiAuth
       end
 
       def populate_content_md5
-        return unless %w(POST PUT).include?(@request.method.to_s.upcase)
+        return unless %w(POST PUT PATCH).include?(@request.method.to_s.upcase)
         @request.headers['Content-MD5'] = calculated_md5
         fetch_headers
       end
 
       def md5_mismatch?
-        if %w(POST PUT).include?(@request.method.to_s.upcase)
+        if %w(POST PUT PATCH).include?(@request.method.to_s.upcase)
           calculated_md5 != content_md5
         else
           false

--- a/lib/api_auth/request_drivers/rack.rb
+++ b/lib/api_auth/request_drivers/rack.rb
@@ -26,13 +26,13 @@ module ApiAuth
       end
 
       def populate_content_md5
-        return unless %w(POST PUT).include?(@request.request_method)
+        return unless %w(POST PUT PATCH).include?(@request.request_method)
         @request.env['Content-MD5'] = calculated_md5
         fetch_headers
       end
 
       def md5_mismatch?
-        if %w(POST PUT).include?(@request.request_method)
+        if %w(POST PUT PATCH).include?(@request.request_method)
           calculated_md5 != content_md5
         else
           false

--- a/lib/api_auth/request_drivers/rest_client.rb
+++ b/lib/api_auth/request_drivers/rest_client.rb
@@ -29,13 +29,13 @@ module ApiAuth
       end
 
       def populate_content_md5
-        return unless [:post, :put].include?(@request.method)
+        return unless [:post, :put, :patch].include?(@request.method)
         @request.headers['Content-MD5'] = calculated_md5
         save_headers
       end
 
       def md5_mismatch?
-        if [:post, :put].include?(@request.method)
+        if [:post, :put, :patch].include?(@request.method)
           calculated_md5 != content_md5
         else
           false

--- a/spec/request_drivers/action_controller_spec.rb
+++ b/spec/request_drivers/action_controller_spec.rb
@@ -124,6 +124,19 @@ if defined?(ActionController::Request)
           end
         end
 
+        context 'when patching' do
+          it 'populates content-md5' do
+            request.env['REQUEST_METHOD'] = 'PATCH'
+            driven_request.populate_content_md5
+            expect(request.env['Content-MD5']).to eq('kZXQvrKoieG+Be1rsZVINw==')
+          end
+
+          it 'refreshes the cached headers' do
+            driven_request.populate_content_md5
+            expect(driven_request.content_md5).to eq('kZXQvrKoieG+Be1rsZVINw==')
+          end
+        end
+
         context 'when deleting' do
           it "doesn't populate content-md5" do
             request.env['REQUEST_METHOD'] = 'DELETE'
@@ -197,6 +210,32 @@ if defined?(ActionController::Request)
       context 'when putting' do
         before do
           request.env['REQUEST_METHOD'] = 'PUT'
+        end
+
+        context 'when calculated matches sent' do
+          before do
+            request.env['CONTENT_MD5'] = 'kZXQvrKoieG+Be1rsZVINw=='
+          end
+
+          it 'is false' do
+            expect(driven_request.md5_mismatch?).to be false
+          end
+        end
+
+        context "when calculated doesn't match sent" do
+          before do
+            request.env['CONTENT_MD5'] = '3'
+          end
+
+          it 'is true' do
+            expect(driven_request.md5_mismatch?).to be true
+          end
+        end
+      end
+
+      context 'when patching' do
+        before do
+          request.env['REQUEST_METHOD'] = 'PATCH'
         end
 
         context 'when calculated matches sent' do

--- a/spec/request_drivers/action_controller_spec.rb
+++ b/spec/request_drivers/action_controller_spec.rb
@@ -124,16 +124,18 @@ if defined?(ActionController::Request)
           end
         end
 
-        context 'when patching' do
-          it 'populates content-md5' do
-            request.env['REQUEST_METHOD'] = 'PATCH'
-            driven_request.populate_content_md5
-            expect(request.env['Content-MD5']).to eq('kZXQvrKoieG+Be1rsZVINw==')
-          end
+        if ActionController::Request.new({}).respond_to?(:patch?)
+          context 'when patching' do
+            it 'populates content-md5' do
+              request.env['REQUEST_METHOD'] = 'PATCH'
+              driven_request.populate_content_md5
+              expect(request.env['Content-MD5']).to eq('kZXQvrKoieG+Be1rsZVINw==')
+            end
 
-          it 'refreshes the cached headers' do
-            driven_request.populate_content_md5
-            expect(driven_request.content_md5).to eq('kZXQvrKoieG+Be1rsZVINw==')
+            it 'refreshes the cached headers' do
+              driven_request.populate_content_md5
+              expect(driven_request.content_md5).to eq('kZXQvrKoieG+Be1rsZVINw==')
+            end
           end
         end
 
@@ -233,28 +235,30 @@ if defined?(ActionController::Request)
         end
       end
 
-      context 'when patching' do
-        before do
-          request.env['REQUEST_METHOD'] = 'PATCH'
-        end
-
-        context 'when calculated matches sent' do
+      if ActionController::Request.new({}).respond_to?(:patch?)
+        context 'when patching' do
           before do
-            request.env['CONTENT_MD5'] = 'kZXQvrKoieG+Be1rsZVINw=='
+            request.env['REQUEST_METHOD'] = 'PATCH'
           end
 
-          it 'is false' do
-            expect(driven_request.md5_mismatch?).to be false
-          end
-        end
+          context 'when calculated matches sent' do
+            before do
+              request.env['CONTENT_MD5'] = 'kZXQvrKoieG+Be1rsZVINw=='
+            end
 
-        context "when calculated doesn't match sent" do
-          before do
-            request.env['CONTENT_MD5'] = '3'
+            it 'is false' do
+              expect(driven_request.md5_mismatch?).to be false
+            end
           end
 
-          it 'is true' do
-            expect(driven_request.md5_mismatch?).to be true
+          context "when calculated doesn't match sent" do
+            before do
+              request.env['CONTENT_MD5'] = '3'
+            end
+
+            it 'is true' do
+              expect(driven_request.md5_mismatch?).to be true
+            end
           end
         end
       end

--- a/spec/request_drivers/faraday_spec.rb
+++ b/spec/request_drivers/faraday_spec.rb
@@ -150,6 +150,19 @@ describe ApiAuth::RequestDrivers::FaradayRequest do
         end
       end
 
+      context 'when patching' do
+        it 'populates content-md5' do
+          request.method = :patch
+          driven_request.populate_content_md5
+          expect(request.headers['Content-MD5']).to eq('kZXQvrKoieG+Be1rsZVINw==')
+        end
+
+        it 'refreshes the cached headers' do
+          driven_request.populate_content_md5
+          expect(driven_request.content_md5).to eq('kZXQvrKoieG+Be1rsZVINw==')
+        end
+      end
+
       context 'when deleting' do
         it "doesn't populate content-md5" do
           request.method = :delete
@@ -223,6 +236,32 @@ describe ApiAuth::RequestDrivers::FaradayRequest do
     context 'when putting' do
       before do
         request.method = :put
+      end
+
+      context 'when calculated matches sent' do
+        before do
+          request.headers['Content-MD5'] = 'kZXQvrKoieG+Be1rsZVINw=='
+        end
+
+        it 'is false' do
+          expect(driven_request.md5_mismatch?).to be false
+        end
+      end
+
+      context "when calculated doesn't match sent" do
+        before do
+          request.headers['Content-MD5'] = '3'
+        end
+
+        it 'is true' do
+          expect(driven_request.md5_mismatch?).to be true
+        end
+      end
+    end
+
+    context 'when patching' do
+      before do
+        request.method = :patch
       end
 
       context 'when calculated matches sent' do

--- a/spec/request_drivers/rack_spec.rb
+++ b/spec/request_drivers/rack_spec.rb
@@ -165,6 +165,28 @@ describe ApiAuth::RequestDrivers::RackRequest do
         end
       end
 
+      context 'when patching' do
+        let(:request) do
+          Rack::Request.new(
+            Rack::MockRequest.env_for(
+              request_path,
+              :method => :patch,
+              :input => "hello\nworld"
+            ).merge!(request_headers)
+          )
+        end
+
+        it 'populates content-md5' do
+          driven_request.populate_content_md5
+          expect(request.env['Content-MD5']).to eq('kZXQvrKoieG+Be1rsZVINw==')
+        end
+
+        it 'refreshes the cached headers' do
+          driven_request.populate_content_md5
+          expect(driven_request.content_md5).to eq('kZXQvrKoieG+Be1rsZVINw==')
+        end
+      end
+
       context 'when deleting' do
         let(:request) do
           Rack::Request.new(
@@ -260,6 +282,38 @@ describe ApiAuth::RequestDrivers::RackRequest do
           Rack::MockRequest.env_for(
             request_path,
             :method => :put,
+            :input => "hello\nworld"
+          ).merge!(request_headers)
+        )
+      end
+
+      context 'when calculated matches sent' do
+        before do
+          request.env['Content-MD5'] = 'kZXQvrKoieG+Be1rsZVINw=='
+        end
+
+        it 'is false' do
+          expect(driven_request.md5_mismatch?).to be false
+        end
+      end
+
+      context "when calculated doesn't match sent" do
+        before do
+          request.env['Content-MD5'] = '3'
+        end
+
+        it 'is true' do
+          expect(driven_request.md5_mismatch?).to be true
+        end
+      end
+    end
+
+    context 'when patching' do
+      let(:request) do
+        Rack::Request.new(
+          Rack::MockRequest.env_for(
+            request_path,
+            :method => :patch,
             :input => "hello\nworld"
           ).merge!(request_headers)
         )

--- a/spec/request_drivers/rest_client_spec.rb
+++ b/spec/request_drivers/rest_client_spec.rb
@@ -158,6 +158,27 @@ describe ApiAuth::RequestDrivers::RestClientRequest do
         end
       end
 
+      context 'when patching' do
+        let(:request) do
+          RestClient::Request.new(
+            :url => '/resource.xml?foo=bar&bar=foo',
+            :headers => request_headers,
+            :method => :patch,
+            :payload => "hello\nworld"
+          )
+        end
+
+        it 'populates content-md5' do
+          driven_request.populate_content_md5
+          expect(request.headers['Content-MD5']).to eq('kZXQvrKoieG+Be1rsZVINw==')
+        end
+
+        it 'refreshes the cached headers' do
+          driven_request.populate_content_md5
+          expect(driven_request.content_md5).to eq('kZXQvrKoieG+Be1rsZVINw==')
+        end
+      end
+
       context 'when deleting' do
         let(:request) do
           RestClient::Request.new(
@@ -261,6 +282,47 @@ describe ApiAuth::RequestDrivers::RestClientRequest do
           :url => '/resource.xml?foo=bar&bar=foo',
           :headers => request_headers,
           :method => :put,
+          :payload => "hello\nworld"
+        )
+      end
+
+      context 'when calculated matches sent' do
+        let(:request_headers) do
+          {
+            'Authorization' => 'APIAuth 1044:12345',
+            'Content-MD5' => 'kZXQvrKoieG+Be1rsZVINw==',
+            'Content-Type' => 'text/plain',
+            'Date' => timestamp
+          }
+        end
+
+        it 'is false' do
+          expect(driven_request.md5_mismatch?).to be false
+        end
+      end
+
+      context "when calculated doesn't match sent" do
+        let(:request_headers) do
+          {
+            'Authorization' => 'APIAuth 1044:12345',
+            'Content-MD5' => '3',
+            'Content-Type' => 'text/plain',
+            'Date' => timestamp
+          }
+        end
+
+        it 'is true' do
+          expect(driven_request.md5_mismatch?).to be true
+        end
+      end
+    end
+
+    context 'when patching' do
+      let(:request) do
+        RestClient::Request.new(
+          :url => '/resource.xml?foo=bar&bar=foo',
+          :headers => request_headers,
+          :method => :patch,
           :payload => "hello\nworld"
         )
       end


### PR DESCRIPTION
Hi!

In most of cases a PATCH request is similar to POST/PUT. And like POST/PUT, PATCH should carry data in request body. So, MD5 populate/check must be default behavior for PATCH requests.