### PR TITLE
Configurable authorization header

### DIFF
--- a/lib/api_auth.rb
+++ b/lib/api_auth.rb
@@ -16,3 +16,12 @@ require 'api_auth/request_drivers/faraday'
 require 'api_auth/headers'
 require 'api_auth/base'
 require 'api_auth/railtie'
+
+module ApiAuth # :nodoc:
+  class << self
+    attr_accessor :header_to_assign, :header_to_search
+  end
+
+  self.header_to_assign = 'Authorization'
+  self.header_to_search = %w[Authorization AUTHORIZATION HTTP_AUTHORIZATION]
+end

--- a/lib/api_auth/railtie.rb
+++ b/lib/api_auth/railtie.rb
@@ -81,7 +81,7 @@ module ApiAuth
             ApiAuth.sign!(tmp, hmac_access_id, hmac_secret_key, api_auth_options)
             arguments.last['Content-MD5'] = tmp['Content-MD5'] if tmp['Content-MD5']
             arguments.last['DATE'] = tmp['DATE']
-            arguments.last['Authorization'] = tmp['Authorization']
+            arguments.last[ApiAuth.header_to_assign] = tmp[ApiAuth.header_to_assign]
           end
 
           request_without_auth(method, path, *arguments)

--- a/lib/api_auth/request_drivers/action_controller.rb
+++ b/lib/api_auth/request_drivers/action_controller.rb
@@ -10,7 +10,7 @@ module ApiAuth
       end
 
       def set_auth_header(header)
-        @request.env['Authorization'] = header
+        @request.env[ApiAuth.header_to_assign] = header
         fetch_headers
         @request
       end
@@ -71,7 +71,7 @@ module ApiAuth
       end
 
       def authorization_header
-        find_header %w(Authorization AUTHORIZATION HTTP_AUTHORIZATION)
+        find_header ApiAuth.header_to_search
       end
 
       private

--- a/lib/api_auth/request_drivers/curb.rb
+++ b/lib/api_auth/request_drivers/curb.rb
@@ -10,7 +10,7 @@ module ApiAuth
       end
 
       def set_auth_header(header)
-        @request.headers['Authorization'] = header
+        @request.headers[ApiAuth.header_to_assign] = header
         fetch_headers
         @request
       end
@@ -60,7 +60,7 @@ module ApiAuth
       end
 
       def authorization_header
-        find_header %w(Authorization AUTHORIZATION HTTP_AUTHORIZATION)
+        find_header ApiAuth.header_to_search
       end
 
       private

--- a/lib/api_auth/request_drivers/faraday.rb
+++ b/lib/api_auth/request_drivers/faraday.rb
@@ -10,7 +10,7 @@ module ApiAuth
       end
 
       def set_auth_header(header)
-        @request.headers['Authorization'] = header
+        @request.headers[ApiAuth.header_to_assign] = header
         fetch_headers
         @request
       end
@@ -74,7 +74,7 @@ module ApiAuth
       end
 
       def authorization_header
-        find_header %w(Authorization AUTHORIZATION HTTP_AUTHORIZATION)
+        find_header ApiAuth.header_to_search
       end
 
       private

--- a/lib/api_auth/request_drivers/httpi.rb
+++ b/lib/api_auth/request_drivers/httpi.rb
@@ -10,7 +10,7 @@ module ApiAuth
       end
 
       def set_auth_header(header)
-        @request.headers['Authorization'] = header
+        @request.headers[ApiAuth.header_to_assign] = header
         fetch_headers
         @request
       end
@@ -70,7 +70,7 @@ module ApiAuth
       end
 
       def authorization_header
-        find_header %w(Authorization AUTHORIZATION HTTP_AUTHORIZATION)
+        find_header ApiAuth.header_to_search
       end
 
       private

--- a/lib/api_auth/request_drivers/net_http.rb
+++ b/lib/api_auth/request_drivers/net_http.rb
@@ -11,7 +11,7 @@ module ApiAuth
       end
 
       def set_auth_header(header)
-        @request['Authorization'] = header
+        @request[ApiAuth.header_to_assign] = header
         @headers = fetch_headers
         @request
       end
@@ -76,7 +76,7 @@ module ApiAuth
       end
 
       def authorization_header
-        find_header %w(Authorization AUTHORIZATION HTTP_AUTHORIZATION)
+        find_header ApiAuth.header_to_search
       end
 
       private

--- a/lib/api_auth/request_drivers/rack.rb
+++ b/lib/api_auth/request_drivers/rack.rb
@@ -10,7 +10,7 @@ module ApiAuth
       end
 
       def set_auth_header(header)
-        @request.env['Authorization'] = header
+        @request.env[ApiAuth.header_to_assign] = header
         fetch_headers
         @request
       end
@@ -76,7 +76,7 @@ module ApiAuth
       end
 
       def authorization_header
-        find_header %w(Authorization AUTHORIZATION HTTP_AUTHORIZATION)
+        find_header ApiAuth.header_to_search
       end
 
       private

--- a/lib/api_auth/request_drivers/rest_client.rb
+++ b/lib/api_auth/request_drivers/rest_client.rb
@@ -13,7 +13,7 @@ module ApiAuth
       end
 
       def set_auth_header(header)
-        @request.headers['Authorization'] = header
+        @request.headers[ApiAuth.header_to_assign] = header
         save_headers # enforce update of processed_headers based on last updated headers
         @request
       end
@@ -79,7 +79,7 @@ module ApiAuth
       end
 
       def authorization_header
-        find_header %w(Authorization AUTHORIZATION HTTP_AUTHORIZATION)
+        find_header ApiAuth.header_to_search
       end
 
       private


### PR DESCRIPTION
Instead of always using the Authorization, allow the use of arbitrary
headers.  This is useful if you are in an environment that uses
BasicAuth for other things.

Example usage in a rails project:

# config/initializers/api_auth.rb
ApiAuth.header_to_assign = 'HMAC_AUTH'
ApiAuth.header_to_search = %w[HMAC_AUTH HTTP_HMAC_AUTH]