### PR TITLE
Mention BUNDLE_GEMFILE in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,7 +234,13 @@ take care of all that for you.
 
 To run the tests:
 
-    rake spec
+Install the dependencies for a particular Rails version by specifying a gemfile in `gemfiles` directory:
+
+    BUNDLE_GEMFILE=gemfiles/rails_5.gemfile bundle install
+
+Run the tests with those dependencies:
+
+    BUNDLE_GEMFILE=gemfiles/rails_5.gemfile bundle exec rake
 
 If you'd like to add support for additional HTTP clients, check out the already
 implemented drivers in `lib/api_auth/request_drivers` for reference. All of


### PR DESCRIPTION
Update the README to mention that `BUNDLE_GEMFILE` has to be set in order for the tests to run correctly, which reflects how tests are run in Travis.

When the tests are run in Travis, the environment variable `BUNDLE_GEMFILE` is set to one of the gemfiles in the `gemfiles/` directory.

Running the `bundle exec rake spec` command without a `BUNDLE_GEMFILE` causes all the tests to fail with `LoadError: cannot load such file -- rails`