### PR TITLE
URI edge case: having another URI in the URI

### DIFF
--- a/lib/api_auth/headers.rb
+++ b/lib/api_auth/headers.rb
@@ -93,12 +93,12 @@ module ApiAuth
 
     private
 
-    URI_WITHOUT_HOST_REGEXP = %r{https?://[^,?/]*}
-
     def parse_uri(uri)
-      uri_without_host = uri.gsub(URI_WITHOUT_HOST_REGEXP, '')
-      return '/' if uri_without_host.empty?
-      uri_without_host
+      parsed_uri = URI.parse(uri)
+
+      return parsed_uri.request_uri if parsed_uri.respond_to?(:request_uri)
+
+      uri.empty? ? '/' : uri
     end
   end
 end

--- a/spec/headers_spec.rb
+++ b/spec/headers_spec.rb
@@ -38,6 +38,18 @@ describe ApiAuth::Headers do
           expect(request.url).to eq(uri)
         end
       end
+
+      context 'uri has a string matching http:// in it' do
+        let(:uri) { 'http://google.com/?redirect_to=https://www.example.com'.freeze }
+
+        it 'return /?redirect_to=https://www.example.com as canonical string path' do
+          expect(subject.canonical_string).to eq('GET,,,/?redirect_to=https://www.example.com,')
+        end
+
+        it 'does not change request url (by removing host)' do
+          expect(request.url).to eq(uri)
+        end
+      end
     end
 
     context 'string construction' do


### PR DESCRIPTION
The regular expression used in the `ApiAuth::Headers#parse_uri` method matches all strings that look like hosts in the uri, not only the real host.

For example, `https://www.google.com/?redirect_to=https://www.example.com` is turned into `/?redirect_to=` when it should be `/?redirect_to=https://www.example.com`.

This commit adds a test for that case and fixes it by using Ruby's `URI.parse` method instead of a custom regexp.