### PR TITLE
add new 'headers_to_sign' option to sign custom headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,14 @@ to:
 
     Authorization = APIAuth-HMAC-DIGEST_NAME 'client access id':'signature'
 
+If you want to sign custom headers, you can pass them as an array of strings in the options like so:
+
+``` ruby
+    @signed_request = ApiAuth.sign!(@request, @access_id, @secret_key, headers_to_sign: %w[HTTP_HEADER_NAME])
+```
+
+With the specified headers values being at the end of the canonical string in the same order.
+
 ### ActiveResource Clients
 
 ApiAuth can transparently protect your ActiveResource communications with a

--- a/lib/api_auth/base.rb
+++ b/lib/api_auth/base.rb
@@ -105,7 +105,7 @@ module ApiAuth
     end
 
     def hmac_signature(headers, secret_key, options)
-      canonical_string = headers.canonical_string(options[:override_http_method])
+      canonical_string = headers.canonical_string(options[:override_http_method], options[:headers_to_sign])
       digest = OpenSSL::Digest.new(options[:digest])
       b64_encode(OpenSSL::HMAC.digest(digest, secret_key, canonical_string))
     end

--- a/lib/api_auth/headers.rb
+++ b/lib/api_auth/headers.rb
@@ -50,16 +50,24 @@ module ApiAuth
       @request.timestamp
     end
 
-    def canonical_string(override_method = nil)
+    def canonical_string(override_method = nil, headers_to_sign = [])
       request_method = override_method || @request.http_method
 
       raise ArgumentError, 'unable to determine the http method from the request, please supply an override' if request_method.nil?
 
-      [request_method.upcase,
-       @request.content_type,
-       @request.content_md5,
-       parse_uri(@request.original_uri || @request.request_uri),
-       @request.timestamp].join(',')
+      headers = @request.fetch_headers
+
+      canonical_array = [request_method.upcase,
+                         @request.content_type,
+                         @request.content_md5,
+                         parse_uri(@request.original_uri || @request.request_uri),
+                         @request.timestamp]
+
+      if headers_to_sign.is_a?(Array) && headers_to_sign.any?
+        headers_to_sign.each { |h| canonical_array << headers[h] if headers[h].present? }
+      end
+
+      canonical_array.join(',')
     end
 
     # Returns the authorization header from the request's headers

--- a/spec/api_auth_spec.rb
+++ b/spec/api_auth_spec.rb
@@ -169,6 +169,13 @@ describe 'ApiAuth' do
         expect(ApiAuth.authentic?(signed_request, '123', clock_skew: 60.seconds)).to eq false
       end
     end
+
+    context 'when passed the headers_to_sign option' do
+      it 'validates the request' do
+        request['X-Forwarded-For'] = '192.168.1.1'
+        expect(ApiAuth.authentic?(signed_request, '123', headers_to_sign: %w[HTTP_X_FORWARDED_FOR])).to eq true
+      end
+    end
   end
 
   describe '.access_id' do


### PR DESCRIPTION
Hello,

This adds the possibility to sign custom/specified headers via a headers_to_sign
option that will be passed as an array containing the headers names

To add more context into this, we would like to be able to sign the `X-Forwarded-For` header for instance