### PR TITLE
correct README.md for signed headers option

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,14 +139,6 @@ to:
 
     Authorization = APIAuth-HMAC-DIGEST_NAME 'client access id':'signature'
 
-If you want to sign custom headers, you can pass them as an array of strings in the options like so:
-
-``` ruby
-    @signed_request = ApiAuth.sign!(@request, @access_id, @secret_key, headers_to_sign: %w[HTTP_HEADER_NAME])
-```
-
-With the specified headers values being at the end of the canonical string in the same order.
-
 ### ActiveResource Clients
 
 ApiAuth can transparently protect your ActiveResource communications with a
@@ -209,6 +201,14 @@ The default span is 15 minutes, but you can override this:
 ```ruby
     ApiAuth.authentic?(signed_request, secret_key, :clock_skew => 60) # or 1.minute in ActiveSupport
 ```
+
+If you want to sign custom headers, you can pass them as an array of strings in the options like so:
+
+``` ruby
+    ApiAuth.authentic?(signed_request, secret_key, headers_to_sign: %w[HTTP_HEADER_NAME])
+```
+
+With the specified headers values being at the end of the canonical string in the same order.
 
 If your server is a Rails app, the signed request will be the `request` object.
 


### PR DESCRIPTION
correct documentation for headers_to_sign option

introduced in https://github.com/mgomes/api_auth/pull/170