### PR TITLE
Fix unit test pipeline and add ruby 2.6 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ rvm:
   - 2.3.6
   - 2.4.3
   - 2.5.3
+  - 2.6.1
 gemfile:
   - gemfiles/rails_4.gemfile
   - gemfiles/rails_41.gemfile
@@ -26,7 +27,7 @@ script:
 
 matrix:
   include:
-    - rvm: 2.5.3
+    - rvm: 2.6.1
       gemfile: gemfiles/rails_5.gemfile
       env: TEST_SUITE="rubocop lib/ spec/"
 

--- a/gemfiles/rails_5.gemfile
+++ b/gemfiles/rails_5.gemfile
@@ -3,7 +3,7 @@
 source 'https://rubygems.org'
 
 gem 'actionpack', '~> 5.0.2'
-gem 'activeresource', '~> 5.0.0', git: 'https://github.com/rails/activeresource.git'
+gem 'activeresource', '~> 5.0.0'
 gem 'activesupport', '~> 5.0.2'
 
 gem 'rubocop'

--- a/gemfiles/rails_51.gemfile
+++ b/gemfiles/rails_51.gemfile
@@ -3,7 +3,7 @@
 source 'https://rubygems.org'
 
 gem 'actionpack', '~> 5.1.1'
-gem 'activeresource', '~> 5.0.0', git: 'https://github.com/rails/activeresource.git'
+gem 'activeresource', '~> 5.1.0'
 gem 'activesupport', '~> 5.1.1'
 
 gemspec path: '../'

--- a/gemfiles/rails_52.gemfile
+++ b/gemfiles/rails_52.gemfile
@@ -3,7 +3,7 @@
 source 'https://rubygems.org'
 
 gem 'actionpack', '~> 5.2.1'
-gem 'activeresource', '~> 5.0.0', git: 'https://github.com/rails/activeresource.git'
+gem 'activeresource', '~> 5.1.0'
 gem 'activesupport', '~> 5.2.1'
 
 gemspec path: '../'


### PR DESCRIPTION
- Fix the unit test pipeline

https://travis-ci.org/mgomes/api_auth/jobs/451423574

```
$ bundle install --jobs=3 --retry=3 --path=${BUNDLE_PATH:-vendor/bundle}
Fetching https://github.com/rails/activeresource.git
Fetching gem metadata from https://rubygems.org/........
Fetching gem metadata from https://rubygems.org/.
Could not find gem 'activeresource (~> 5.0.0)' in
https://github.com/rails/activeresource.git (at master@326b452).
The source contains 'activeresource' at: 5.1.0
```

- Add ruby 2.6
