### PR TITLE
Fix Rails 6 ActionController::Base deprecation warnings

### DIFF
--- a/lib/api_auth/railtie.rb
+++ b/lib/api_auth/railtie.rb
@@ -13,7 +13,9 @@ module ApiAuth
         end
       end
 
-      ActionController::Base.include(ControllerMethods::InstanceMethods) if defined?(ActionController::Base)
+      ActiveSupport.on_load(:action_controller) do
+        ActionController::Base.include(ControllerMethods::InstanceMethods)
+      end
     end # ControllerMethods
 
     module ActiveResourceExtension # :nodoc:
@@ -78,7 +80,7 @@ module ApiAuth
         end
       end # Connection
 
-      if defined?(ActiveResource)
+      ActiveSupport.on_load(:active_resource) do
         ActiveResource::Base.include(ActiveResourceApiAuth)
         ActiveResource::Connection.include(Connection)
       end


### PR DESCRIPTION
Referencing `ActionController::Base` within an initializer or railtie causes Rails to print a deprecation warning. The relevant Rails issue is here: https://github.com/rails/rails/issues/36546

This is fixed by using `ActiveSupport.on_load` before referencing the module in the railtie. I chose to use the `:action_controller` hook name because the more appropriate `:action_controller_base` hook is only available in Rails versions `>= 5.1`. If it's preferable, we could check the Rails version and set the hook name conditionally.