### PR TITLE
Fix Rubocop warnings after recent changes to Rubocop

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -65,7 +65,7 @@ Naming/AccessorMethodName:
 # Offense count: 3
 # Configuration parameters: MinNameLength, AllowNamesEndingInNumbers, AllowedNames, ForbiddenNames.
 # AllowedNames: io, id, to, by, on, in, at, ip, db
-Naming/UncommunicativeMethodParamName:
+Naming/MethodParameterName:
   Exclude:
     - 'lib/api_auth/base.rb'
     - 'spec/railtie_spec.rb'

--- a/lib/api_auth/railtie.rb
+++ b/lib/api_auth/railtie.rb
@@ -13,7 +13,7 @@ module ApiAuth
         end
       end
 
-      ActionController::Base.send(:include, ControllerMethods::InstanceMethods) if defined?(ActionController::Base)
+      ActionController::Base.include(ControllerMethods::InstanceMethods) if defined?(ActionController::Base)
     end # ControllerMethods
 
     module ActiveResourceExtension # :nodoc:
@@ -79,8 +79,8 @@ module ApiAuth
       end # Connection
 
       if defined?(ActiveResource)
-        ActiveResource::Base.send(:include, ActiveResourceApiAuth)
-        ActiveResource::Connection.send(:include, Connection)
+        ActiveResource::Base.include(ActiveResourceApiAuth)
+        ActiveResource::Connection.include(Connection)
       end
     end # ActiveResourceExtension
   end # Rails

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -21,4 +21,4 @@ require 'net/http/post/multipart'
 
 # Requires supporting files with custom matchers and macros, etc,
 # in ./support/ and its subdirectories.
-Dir["#{File.dirname(__FILE__)}/support/**/*.rb"].each { |f| require f }
+Dir["#{File.dirname(__FILE__)}/support/**/*.rb"].sort.each { |f| require f }


### PR DESCRIPTION
A recent cop name change is causing the Rubocop section of CI to fail. This fixes the cop name, and fixes some include statements to adhere to newly added lint cops.