### PR TITLE
Check for ActiveSupport presence in railtie definition

### DIFF
--- a/lib/api_auth/railtie.rb
+++ b/lib/api_auth/railtie.rb
@@ -13,8 +13,10 @@ module ApiAuth
         end
       end
 
-      ActiveSupport.on_load(:action_controller) do
-        ActionController::Base.include(ControllerMethods::InstanceMethods)
+      if defined?(ActiveSupport)
+        ActiveSupport.on_load(:action_controller) do
+          ActionController::Base.include(ControllerMethods::InstanceMethods)
+        end
       end
     end # ControllerMethods
 
@@ -80,9 +82,11 @@ module ApiAuth
         end
       end # Connection
 
-      ActiveSupport.on_load(:active_resource) do
-        ActiveResource::Base.include(ActiveResourceApiAuth)
-        ActiveResource::Connection.include(Connection)
+      if defined?(ActiveSupport)
+        ActiveSupport.on_load(:active_resource) do
+          ActiveResource::Base.include(ActiveResourceApiAuth)
+          ActiveResource::Connection.include(Connection)
+        end
       end
     end # ActiveResourceExtension
   end # Rails


### PR DESCRIPTION
This PR is related to the accidental introduction of an ActiveSupport dependency into the gem. `api_auth` should be able to be used without Rails (and therefore without ActiveSupport). Because the [railtie is always included when the gem is loaded](https://github.com/mgomes/api_auth/blob/master/lib/api_auth.rb#L21), the railtie is loaded even when Rails is not.

This was not historically an issue because before the merging of [my pull request to fix a related deprecation warning](https://github.com/mgomes/api_auth/pull/179), we checked for the definition of `ActiveController::Base`, which meant that the railtie file could be required even if Rails was not.

Because the definition check was the source of the deprecation warning that I fixed in my original PR, my change had the effect of breaking the railtie inclusion if ActiveSupport is not bundled.

This PR solves the issue by checking for the definition of ActiveSupport before using the `on_load` hooks. An alternative solution (which might make more sense) would be to conditionally include the railtie in its entirety [here](https://github.com/mgomes/api_auth/blob/master/lib/api_auth.rb#L21):

```ruby
# ...
require 'api_auth/railtie' if defined?(::Rails)
```

Let me know what you think about how this problem should be solved.