### PR TITLE
Adding license information to the gemspec

### DIFF
--- a/api_auth.gemspec
+++ b/api_auth.gemspec
@@ -8,6 +8,7 @@ Gem::Specification.new do |s|
   s.version = File.read(File.join(File.dirname(__FILE__), 'VERSION'))
   s.authors = ['Mauricio Gomes']
   s.email = 'mauricio@edge14.com'
+  s.license = 'MIT'
 
   s.required_ruby_version = '>= 2.5.0'
 


### PR DESCRIPTION
Tools like VersionEye are using this kind of information for license compliance analysis.