### PR TITLE
Add a MD5 compatibility option in authentic? method

### DIFF
--- a/lib/api_auth/base.rb
+++ b/lib/api_auth/base.rb
@@ -32,9 +32,9 @@ module ApiAuth
     def authentic?(request, secret_key, options = {})
       return false if secret_key.nil?
 
-      options = { override_http_method: nil }.merge(options)
+      options = { override_http_method: nil, authorize_md5: false }.merge(options)
 
-      headers = Headers.new(request)
+      headers = Headers.new(request, authorize_md5: options[:authorize_md5])
 
       # 900 seconds is 15 minutes
       clock_skew = options.fetch(:clock_skew, 900)

--- a/lib/api_auth/headers.rb
+++ b/lib/api_auth/headers.rb
@@ -3,13 +3,13 @@ module ApiAuth
   class Headers
     include RequestDrivers
 
-    def initialize(request)
+    def initialize(request, authorize_md5: false)
       @original_request = request
-      @request = initialize_request_driver(request)
+      @request = initialize_request_driver(request, authorize_md5: authorize_md5)
       true
     end
 
-    def initialize_request_driver(request)
+    def initialize_request_driver(request, authorize_md5: false)
       new_request =
         case request.class.to_s
         when /Net::HTTP/
@@ -29,7 +29,7 @@ module ApiAuth
         when /Grape::Request/
           GrapeRequest.new(request)
         when /ActionDispatch::Request/
-          ActionDispatchRequest.new(request)
+          ActionDispatchRequest.new(request, authorize_md5: authorize_md5)
         when /ActionController::CgiRequest/
           ActionControllerRequest.new(request)
         when /HTTPI::Request/

--- a/lib/api_auth/helpers.rb
+++ b/lib/api_auth/helpers.rb
@@ -8,6 +8,10 @@ module ApiAuth
       Digest::SHA256.base64digest(string)
     end
 
+    def md5_base64digest(string)
+      Digest::MD5.base64digest(string)
+    end
+
     # Capitalizes the keys of a hash
     def capitalize_keys(hsh)
       capitalized_hash = {}

--- a/spec/request_drivers/action_dispatch_spec.rb
+++ b/spec/request_drivers/action_dispatch_spec.rb
@@ -5,6 +5,7 @@ if defined?(ActionDispatch::Request)
   describe ApiAuth::RequestDrivers::ActionDispatchRequest do
     let(:timestamp) { Time.now.utc.httpdate }
     let(:content_sha256) { '47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=' }
+    let(:content_md5) { '+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=' }
 
     let(:request) do
       ActionDispatch::Request.new(
@@ -48,7 +49,26 @@ if defined?(ActionDispatch::Request)
       )
     end
 
+    let(:request_md5) do
+      ActionDispatch::Request.new(
+        'AUTHORIZATION' => 'APIAuth 1044:12345',
+        'PATH_INFO' => '/resource.xml',
+        'QUERY_STRING' => 'foo=bar&bar=foo',
+        'REQUEST_METHOD' => 'PUT',
+        'CONTENT_MD5' => content_md5,
+        'CONTENT_TYPE' => 'text/plain',
+        'CONTENT_LENGTH' => '11',
+        'HTTP_DATE' => timestamp,
+        'rack.input' => StringIO.new("hello\nworld")
+      )
+    end
+
     subject(:driven_request) { ApiAuth::RequestDrivers::ActionDispatchRequest.new(request) }
+    subject(:driven_request_md5) do
+      ApiAuth::RequestDrivers::ActionDispatchRequest.new(request_md5,
+                                                         authorize_md5: true)
+    end
+    subject(:driven_request_sha2_with_md5) { ApiAuth::RequestDrivers::ActionDispatchRequest.new(request, authorize_md5: true) }
 
     describe 'getting headers correctly' do
       it 'gets the content_type' do
@@ -69,6 +89,11 @@ if defined?(ActionDispatch::Request)
         expect(example_request.content_hash).to eq(content_sha256)
       end
 
+      it 'gets the content_hash for request_md5' do
+        example_request = ApiAuth::RequestDrivers::ActionDispatchRequest.new(request_md5, authorize_md5: true)
+        expect(example_request.content_hash).to eq(content_md5)
+      end
+
       it 'gets the request_uri' do
         expect(driven_request.request_uri).to eq('/resource.xml?foo=bar&bar=foo')
       end
@@ -83,13 +108,17 @@ if defined?(ActionDispatch::Request)
 
       describe '#calculated_hash' do
         it 'calculates hash from the body' do
-          expect(driven_request.calculated_hash).to eq('JsYKYdAdtYNspw/v1EpqAWYgQTyO9fJZpsVhLU9507g=')
+          expect(driven_request.calculated_hash).to eq(['JsYKYdAdtYNspw/v1EpqAWYgQTyO9fJZpsVhLU9507g='])
+        end
+
+        it 'calculates hashes from the body with md5 compatibility option' do
+          expect(driven_request_md5.calculated_hash).to eq(%w[JsYKYdAdtYNspw/v1EpqAWYgQTyO9fJZpsVhLU9507g= kZXQvrKoieG+Be1rsZVINw==])
         end
 
         it 'treats no body as empty string' do
           request.env['rack.input'] = StringIO.new
           request.env['CONTENT_LENGTH'] = 0
-          expect(driven_request.calculated_hash).to eq('47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=')
+          expect(driven_request.calculated_hash).to eq(['47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU='])
         end
       end
 
@@ -141,12 +170,12 @@ if defined?(ActionDispatch::Request)
           it 'populates content hash' do
             request.env['REQUEST_METHOD'] = 'POST'
             driven_request.populate_content_hash
-            expect(request.env['X-AUTHORIZATION-CONTENT-SHA256']).to eq('JsYKYdAdtYNspw/v1EpqAWYgQTyO9fJZpsVhLU9507g=')
+            expect(request.env['X-AUTHORIZATION-CONTENT-SHA256']).to eq(['JsYKYdAdtYNspw/v1EpqAWYgQTyO9fJZpsVhLU9507g='])
           end
 
           it 'refreshes the cached headers' do
             driven_request.populate_content_hash
-            expect(driven_request.content_hash).to eq('JsYKYdAdtYNspw/v1EpqAWYgQTyO9fJZpsVhLU9507g=')
+            expect(driven_request.content_hash).to eq(['JsYKYdAdtYNspw/v1EpqAWYgQTyO9fJZpsVhLU9507g='])
           end
         end
 
@@ -154,12 +183,12 @@ if defined?(ActionDispatch::Request)
           it 'populates content hash' do
             request.env['REQUEST_METHOD'] = 'PUT'
             driven_request.populate_content_hash
-            expect(request.env['X-AUTHORIZATION-CONTENT-SHA256']).to eq('JsYKYdAdtYNspw/v1EpqAWYgQTyO9fJZpsVhLU9507g=')
+            expect(request.env['X-AUTHORIZATION-CONTENT-SHA256']).to eq(['JsYKYdAdtYNspw/v1EpqAWYgQTyO9fJZpsVhLU9507g='])
           end
 
           it 'refreshes the cached headers' do
             driven_request.populate_content_hash
-            expect(driven_request.content_hash).to eq('JsYKYdAdtYNspw/v1EpqAWYgQTyO9fJZpsVhLU9507g=')
+            expect(driven_request.content_hash).to eq(['JsYKYdAdtYNspw/v1EpqAWYgQTyO9fJZpsVhLU9507g='])
           end
         end
 
@@ -200,35 +229,63 @@ if defined?(ActionDispatch::Request)
       context 'when getting' do
         before do
           request.env['REQUEST_METHOD'] = 'GET'
+          request_md5.env['REQUEST_METHOD'] = 'GET'
         end
 
         it 'is false' do
           expect(driven_request.content_hash_mismatch?).to be false
+        end
+
+        it 'is false with md5' do
+          expect(driven_request_md5.content_hash_mismatch?).to be false
+        end
+
+        it 'is false with sha2 and md5 compatibility on' do
+          expect(driven_request_sha2_with_md5.content_hash_mismatch?).to be false
         end
       end
 
       context 'when posting' do
         before do
           request.env['REQUEST_METHOD'] = 'POST'
+          request_md5.env['REQUEST_METHOD'] = 'POST'
         end
 
         context 'when calculated matches sent' do
           before do
             request.env['X-AUTHORIZATION-CONTENT-SHA256'] = 'JsYKYdAdtYNspw/v1EpqAWYgQTyO9fJZpsVhLU9507g='
+            request_md5.env['CONTENT_MD5'] = 'kZXQvrKoieG+Be1rsZVINw=='
           end
 
           it 'is false' do
             expect(driven_request.content_hash_mismatch?).to be false
+          end
+
+          it 'is false with md5' do
+            expect(driven_request_md5.content_hash_mismatch?).to be false
+          end
+
+          it 'is false with sha2 and md5 compatibility on' do
+            expect(driven_request_sha2_with_md5.content_hash_mismatch?).to be false
           end
         end
 
         context "when calculated doesn't match sent" do
           before do
             request.env['X-AUTHORIZATION-CONTENT-SHA256'] = '3'
+            request_md5.env['CONTENT_MD5'] = '3'
           end
 
           it 'is true' do
             expect(driven_request.content_hash_mismatch?).to be true
+          end
+
+          it 'is true with md5' do
+            expect(driven_request.content_hash_mismatch?).to be true
+          end
+
+          it 'is true with sha2 and md5 compatibility on' do
+            expect(driven_request_sha2_with_md5.content_hash_mismatch?).to be true
           end
         end
       end
@@ -236,25 +293,44 @@ if defined?(ActionDispatch::Request)
       context 'when putting' do
         before do
           request.env['REQUEST_METHOD'] = 'PUT'
+          request_md5.env['REQUEST_METHOD'] = 'PUT'
         end
 
         context 'when calculated matches sent' do
           before do
             request.env['X-AUTHORIZATION-CONTENT-SHA256'] = 'JsYKYdAdtYNspw/v1EpqAWYgQTyO9fJZpsVhLU9507g='
+            request_md5.env['CONTENT_MD5'] = 'kZXQvrKoieG+Be1rsZVINw=='
           end
 
           it 'is false' do
             expect(driven_request.content_hash_mismatch?).to be false
+          end
+
+          it 'is false with md5' do
+            expect(driven_request_md5.content_hash_mismatch?).to be false
+          end
+
+          it 'is false with sha2 and md5 compatibility on' do
+            expect(driven_request_sha2_with_md5.content_hash_mismatch?).to be false
           end
         end
 
         context "when calculated doesn't match sent" do
           before do
             request.env['X-AUTHORIZATION-CONTENT-SHA256'] = '3'
+            request_md5.env['CONTENT_MD5'] = '3'
           end
 
           it 'is true' do
             expect(driven_request.content_hash_mismatch?).to be true
+          end
+
+          it 'is true with md5' do
+            expect(driven_request_md5.content_hash_mismatch?).to be true
+          end
+
+          it 'is true with sha2 and md5 compatibility on' do
+            expect(driven_request_sha2_with_md5.content_hash_mismatch?).to be true
           end
         end
       end
@@ -262,10 +338,19 @@ if defined?(ActionDispatch::Request)
       context 'when deleting' do
         before do
           request.env['REQUEST_METHOD'] = 'DELETE'
+          request_md5.env['REQUEST_METHOD'] = 'DELETE'
         end
 
         it 'is false' do
           expect(driven_request.content_hash_mismatch?).to be false
+        end
+
+        it 'is false with md5' do
+          expect(driven_request_md5.content_hash_mismatch?).to be false
+        end
+
+        it 'is false with sha2 and md5 compatibility on' do
+          expect(driven_request_sha2_with_md5.content_hash_mismatch?).to be false
         end
       end
     end


### PR DESCRIPTION
In order to facilitate the transition between 2.4.* and 2.5.*, I propose here an option for `base#authentic?` named `authorize_md5` that is set to `false` by default. If `authorize_md5` is set to true, the server will accept both `CONTENT_MD5` and `X_AUTHORIZATION_CONTENT_SHA256` headers.

This feature is designed to be transparent for SHA-256 users, and to permit MD5 users to work both with MD5 and SHA-256