### PR TITLE
Reduce gem size by excluding test files

### DIFF
--- a/api_auth.gemspec
+++ b/api_auth.gemspec
@@ -36,6 +36,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rubocop', '~> 1.50'
   s.add_development_dependency 'typhoeus', '~> 1.4'
 
-  s.files         = `git ls-files lib`.split($/) + ["LICENSE.txt", "CHANGELOG.md", "README.md"]
+  s.files         = `git ls-files lib`.split($/) + ["LICENSE.txt", "CHANGELOG.md", "README.md", "VERSION"]
   s.require_paths = ['lib']
 end

--- a/api_auth.gemspec
+++ b/api_auth.gemspec
@@ -36,7 +36,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rubocop', '~> 1.50'
   s.add_development_dependency 'typhoeus', '~> 1.4'
 
-  s.files         = `git ls-files`.split("\n")
-  s.executables   = `git ls-files -- bin/*`.split("\n").map { |f| File.basename(f) }
+  s.files         = `git ls-files lib`.split($/) + ["LICENSE.txt", "CHANGELOG.md", "README.md"]
   s.require_paths = ['lib']
 end

--- a/api_auth.gemspec
+++ b/api_auth.gemspec
@@ -36,6 +36,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rubocop', '~> 1.50'
   s.add_development_dependency 'typhoeus', '~> 1.4'
 
-  s.files         = `git ls-files lib`.split($/) + ["LICENSE.txt", "CHANGELOG.md", "README.md", "VERSION"]
+  s.files         = `git ls-files lib`.split("\n") + ['LICENSE.txt', 'CHANGELOG.md', 'README.md', 'VERSION']
   s.require_paths = ['lib']
 end

--- a/lib/api_auth/request_drivers/rest_client.rb
+++ b/lib/api_auth/request_drivers/rest_client.rb
@@ -1,5 +1,6 @@
 # give access to RestClient @processed_headers
-module RestClient; class Request; attr_accessor :processed_headers; end; end
+
+require_relative '../../rest_client/request_patch'
 
 module ApiAuth
   module RequestDrivers # :nodoc:

--- a/lib/rest_client/request_patch.rb
+++ b/lib/rest_client/request_patch.rb
@@ -1,0 +1,6 @@
+module RestClient
+  # Adds accessor for processed_headers used by ApiAuth.
+  class Request
+    attr_accessor :processed_headers
+  end
+end


### PR DESCRIPTION
This pull request updates the *.gemspec file to optimize the gem package size and structure

```bash
$ gem build -o before.tar

$ git switch reduce-gem-size

$ gem build -o after.tar

$ du -sh before.tar after.tar
 44K	before.tar
 24K	after.tar
 ```
 
| Metric | Before | After | Saved                 |
|--------|--------|-------|-----------------------|
| Size   | 44K   | 24K   | −20K (⏷ −45.5%)    |


###  whitch files was deleted?

```diff
data
-├── api_auth.gemspec
-├── Appraisals
 ├── CHANGELOG.md
-├── Gemfile
-├── gemfiles
-│   ├── rails_7.gemfile
-│   ├── rails_8.1.gemfile
-│   └── rails_8.gemfile
 ├── lib
 │   ├── api_auth
 │   │   ├── base.rb
 │   │   ├── errors.rb
 │   │   ├── headers.rb
 │   │   ├── helpers.rb
 │   │   ├── middleware
 │   │   │   └── excon.rb
 │   │   ├── railtie.rb
 │   │   └── request_drivers
 │   │       ├── action_controller.rb
 │   │       ├── action_dispatch.rb
 │   │       ├── curb.rb
 │   │       ├── excon.rb
 │   │       ├── faraday_env.rb
 │   │       ├── faraday.rb
 │   │       ├── grape_request.rb
 │   │       ├── http.rb
 │   │       ├── httpi.rb
 │   │       ├── net_http.rb
 │   │       ├── rack.rb
 │   │       ├── rest_client.rb
 │   │       └── typhoeus_request.rb
 │   ├── api_auth.rb
 │   ├── api-auth.rb
 │   ├── excon
 │   │   └── api_auth.rb
 │   └── faraday
 │       ├── api_auth
 │       │   └── middleware.rb
 │       └── api_auth.rb
 ├── LICENSE.txt
-├── Rakefile
 ├── README.md
-├── spec
-│   ├── api_auth_spec.rb
-│   ├── faraday_middleware_spec.rb
-│   ├── fixtures
-│   │   └── upload.png
-│   ├── headers_spec.rb
-│   ├── helpers_spec.rb
-│   ├── railtie_spec.rb
-│   ├── request_drivers
-│   │   ├── action_controller_spec.rb
-│   │   ├── action_dispatch_spec.rb
-│   │   ├── curb_spec.rb
-│   │   ├── excon_spec.rb
-│   │   ├── faraday_env_spec.rb
-│   │   ├── faraday_spec.rb
-│   │   ├── grape_request_spec.rb
-│   │   ├── http_spec.rb
-│   │   ├── httpi_spec.rb
-│   │   ├── net_http_spec.rb
-│   │   ├── rack_spec.rb
-│   │   ├── rest_client_spec.rb
-│   │   └── typhoeus_request_spec.rb
-│   └── spec_helper.rb
-└── VERSION
```

ps: you can see on [rails repo](https://github.com/rails/rails/blob/main/actioncable/actioncable.gemspec#L20)